### PR TITLE
Feature/61 sonarcloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - dev
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
-  #   branches:
-  #     - dev
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - dev
 
 jobs:
   build:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -44,6 +44,8 @@ jobs:
         run: ./gradlew clean compileJava compileTestJava --info
 
       - name: Run unit tests with coverage
+        id: unit_test
+        continue-on-error: true
         run: ./gradlew unitTest jacocoUnitTestReport --info
 
       - name: SonarCloud Scan
@@ -51,3 +53,10 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew sonar --info
+
+      - name: Fail if tests failed
+        - name: Fail if tests failed
+        if: steps.unit_test.outcome == 'failure'
+        run: |
+          echo "❌ Unit tests failed. Please fix failing tests before merging."
+          exit 1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - dev
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - dev
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  #   branches:
+  #     - dev
 
 jobs:
   build:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,45 @@
+name: SonarQube
+on:
+  # push:
+  #   branches:
+  #     - dev
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - dev
+
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # SonarCloud가 전체 히스토리 분석할 수 있도록록
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+           path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with tests
+        run: ./gradlew clean build --info
+
+      - name: SonarCloud Scan
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # PR에 코멘트를 달기 위해 필요
+        run: ./gradlew sonar --info

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - dev
-      - main
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - dev
-      - main
 
 jobs:
   build:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,31 +1,36 @@
-name: SonarQube
+name: SonarCloud Analysis
+
 on:
-  # push:
-  #   branches:
-  #     - dev
+  push:
+    branches:
+      - dev
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - dev
+      - main
 
 jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # SonarCloud가 전체 히스토리 분석할 수 있도록록
+          fetch-depth: 0  # SonarCloud가 전체 히스토리를 분석할 수 있도록
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
-           path: |
+          path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
@@ -35,11 +40,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with tests
-        run: ./gradlew clean build --info
+      - name: Build project (compile only)
+        run: ./gradlew clean compileJava compileTestJava --info
+
+      - name: Run unit tests with coverage
+        run: ./gradlew unitTest jacocoUnitTestReport --info
 
       - name: SonarCloud Scan
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # PR에 코멘트를 달기 위해 필요
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew sonar --info

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -55,7 +55,6 @@ jobs:
         run: ./gradlew sonar --info
 
       - name: Fail if tests failed
-        - name: Fail if tests failed
         if: steps.unit_test.outcome == 'failure'
         run: |
           echo "❌ Unit tests failed. Please fix failing tests before merging."

--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,11 @@ tasks.named('test') {
         exceptionFormat = "full"
     }
 }
-
 // 통합 테스트 제외하고 실행하는 태스크 (CI에서 사용)
 tasks.register('unitTest', Test) {
-    useJUnitPlatform()
-    excludeTags 'integration'
+    useJUnitPlatform {
+        excludeTags = ['integration']
+    }
     
     testLogging {
         events "passed", "skipped", "failed"
@@ -111,7 +111,6 @@ tasks.register('unitTest', Test) {
         exceptionFormat = "full"
     }
 
-	// JaCoCo 실행 데이터 파일 위치 지정
     finalizedBy jacocoUnitTestReport
 }
 
@@ -125,17 +124,16 @@ tasks.register('jacocoUnitTestReport', JacocoReport) {
         html.outputLocation = file("build/reports/jacoco/unitTest/html")
     }
     
-    // unitTest에서 생성된 실행 데이터 사용
     executionData unitTest
     sourceDirectories.from(files("src/main/java"))
     classDirectories.from(files("build/classes/java/main"))
 }
 
-
 // integrationTest 테스트만 실행하는 태스크 (선택적 사용)
 tasks.register('integrationTest', Test) {
-    useJUnitPlatform()
-    includeTags 'integration'
+    useJUnitPlatform {
+        includeTags = ['integration']
+    }
     
     testLogging {
         events "passed", "skipped", "failed"

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "org.sonarqube" version "7.2.2.6593"
+	id 'jacoco'
 }
 
 group = 'zim.tave'
@@ -10,6 +12,42 @@ version = '0.0.1-SNAPSHOT'
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
+	}
+}
+
+sonar {
+	properties {
+		property "sonar.projectKey", "VoyaMeStudio_Me-mory_backend"
+		property "sonar.organization", "voyamestudio"
+		property "sonar.host.url", "https://sonarcloud.io"
+		
+		// 소스 및 테스트 경로
+		property "sonar.sources", "src/main/java"
+		property "sonar.tests", "src/test/java"
+		property "sonar.java.binaries", "build/classes"
+		property "sonar.java.test.binaries", "build/classes"
+		
+		// 제외할 경로
+		property "sonar.exclusions", """
+			**/build/**,
+			**/bin/**,
+			**/*Application.java,
+			**/config/**,
+			**/dto/**,
+			**/domain/**,
+			**/global/common/exception/**
+		"""
+		
+		// 테스트 제외 경로 (선택적)
+		property "sonar.test.exclusions", "**/*Test.java"
+		
+		// Java 버전
+		property "sonar.java.source", "21"
+		property "sonar.java.target", "21"
+		property "sonar.sourceEncoding", "UTF-8"
+		
+		// Unit 테스트 커버리지 리포트 경로 (unitTest용)
+		property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/unitTest/jacocoUnitTestReport.xml"
 	}
 }
 
@@ -72,7 +110,27 @@ tasks.register('unitTest', Test) {
         showStandardStreams = true
         exceptionFormat = "full"
     }
+
+	// JaCoCo 실행 데이터 파일 위치 지정
+    finalizedBy jacocoUnitTestReport
 }
+
+// Unit 테스트용 JaCoCo 리포트 생성
+tasks.register('jacocoUnitTestReport', JacocoReport) {
+    dependsOn unitTest
+    reports {
+        xml.required = true
+        xml.outputLocation = file("build/reports/jacoco/unitTest/jacocoUnitTestReport.xml")
+        html.required = true
+        html.outputLocation = file("build/reports/jacoco/unitTest/html")
+    }
+    
+    // unitTest에서 생성된 실행 데이터 사용
+    executionData unitTest
+    sourceDirectories.from(files("src/main/java"))
+    classDirectories.from(files("build/classes/java/main"))
+}
+
 
 // integrationTest 테스트만 실행하는 태스크 (선택적 사용)
 tasks.register('integrationTest', Test) {


### PR DESCRIPTION
## 🔗 Related Issue
- #61 

## 📝 Description
- SonarCloud 초기 세팅
  - dev 브랜치에 PR이 날라오면 자동으로 sonarcloud 검사 돌아가기
  - PR 밑에 자동으로 sonarcloud 검사 결과  추가
#### 동작 방식
1. PR 생성/업데이트 시 워크플로우 실행
2. unitTest 실행 (integration 태그 제외)
3. jacocoUnitTestReport로 커버리지 리포트 생성
4. SonarCloud 분석 실행
5. PR에 SonarCloud 결과 코멘트 자동 추가

## 🛠 Changes

- build.gradle 변경 : sonarcloud관련 의존성 추가
- sonarcloud.yml 추가 : github actions 추가

