### PR TITLE
Refactor/66 utc migration

### DIFF
--- a/deploy-docker.sh
+++ b/deploy-docker.sh
@@ -74,7 +74,7 @@ docker run -d \
   --name memory-app \
   --restart unless-stopped \
   -p 8081:8081 \
-  -e SPRING_DATASOURCE_URL="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true" \
+  -e SPRING_DATASOURCE_URL="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true" \
   -e SPRING_DATASOURCE_USERNAME="${DB_USERNAME}" \
   -e SPRING_DATASOURCE_PASSWORD="${DB_PASSWORD}" \
   -e CLOUD_AWS_CREDENTIALS_ACCESS_KEY="${AWS_ACCESS_KEY_ID}" \

--- a/deploy-production-direct.sh
+++ b/deploy-production-direct.sh
@@ -62,7 +62,7 @@ docker run -d \
   --network "$NETWORK_NAME" \
   --restart unless-stopped \
   -p 8081:8081 \
-  -e SPRING_DATASOURCE_URL="jdbc:mysql://memory-mysql:3306/$MYSQL_DATABASE?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true" \
+      -e SPRING_DATASOURCE_URL="jdbc:mysql://memory-mysql:3306/$MYSQL_DATABASE?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true" \
   -e SPRING_DATASOURCE_USERNAME="$MYSQL_USER" \
   -e SPRING_DATASOURCE_PASSWORD="$MYSQL_PASSWORD" \
   "$IMAGE_NAME:$IMAGE_TAG"

--- a/deploy-production-docker.sh
+++ b/deploy-production-docker.sh
@@ -125,7 +125,7 @@ deploy_docker() {
           --name memory-app \
           --restart unless-stopped \
           -p 8081:8081 \
-          -e SPRING_DATASOURCE_URL="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true" \
+          -e SPRING_DATASOURCE_URL="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true" \
           -e SPRING_DATASOURCE_USERNAME="${DB_USERNAME}" \
           -e SPRING_DATASOURCE_PASSWORD="${DB_PASSWORD}" \
           -e CLOUD_AWS_CREDENTIALS_ACCESS_KEY="${AWS_ACCESS_KEY_ID}" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/memory_db?useSSL=false&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/memory_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: memory_user
       SPRING_DATASOURCE_PASSWORD: memory_password
     ports:

--- a/src/main/java/zim/tave/memory/config/JacksonConfig.java
+++ b/src/main/java/zim/tave/memory/config/JacksonConfig.java
@@ -1,0 +1,72 @@
+package zim.tave.memory.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonConfig {
+
+    private static final DateTimeFormatter OFFSET_DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer utcOffsetDateTimeCustomizer() {
+        return builder -> {
+            // Ensure UTC baseline
+            builder.timeZone(TimeZone.getTimeZone("UTC"));
+            builder.serializationInclusion(JsonInclude.Include.NON_NULL);
+            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+            // Force OffsetDateTime format globally (UTC -> "Z")
+            JavaTimeModule javaTimeModule = new JavaTimeModule();
+            javaTimeModule.addSerializer(OffsetDateTime.class, new JsonSerializer<>() {
+                @Override
+                public void serialize(OffsetDateTime value, JsonGenerator gen, SerializerProvider serializers)
+                        throws IOException {
+                    if (value == null) {
+                        gen.writeNull();
+                        return;
+                    }
+                    gen.writeString(value.format(OFFSET_DATE_TIME_FORMATTER));
+                }
+            });
+            javaTimeModule.addDeserializer(OffsetDateTime.class, new JsonDeserializer<>() {
+                @Override
+                public OffsetDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                    String raw = p.getValueAsString();
+                    if (raw == null || raw.isBlank()) {
+                        return null;
+                    }
+                    return OffsetDateTime.parse(raw, OFFSET_DATE_TIME_FORMATTER);
+                }
+            });
+
+            builder.modules(javaTimeModule);
+        };
+    }
+
+    /**
+     * Helper for normalizing an OffsetDateTime to UTC when needed.
+     * (Not wired automatically; kept for consistency utilities if required.)
+     */
+    public static OffsetDateTime normalizeToUtc(OffsetDateTime value) {
+        return value == null ? null : value.withOffsetSameInstant(ZoneOffset.UTC);
+    }
+}
+

--- a/src/main/java/zim/tave/memory/domain/Board.java
+++ b/src/main/java/zim/tave/memory/domain/Board.java
@@ -4,7 +4,8 @@ package zim.tave.memory.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,9 +24,9 @@ public class Board {
     private String title;
 
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
-    private LocalDateTime updatedAt;
+    private OffsetDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
@@ -40,11 +41,13 @@ public class Board {
 
     @PrePersist
     public void prePersist() {
-        createdAt = LocalDateTime.now();
+        if (this.createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
     }
 
     @PreUpdate
     public void preUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/zim/tave/memory/domain/Diary.java
+++ b/src/main/java/zim/tave/memory/domain/Diary.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class Diary {
     private String city;
 
     @Column(nullable = false)
-    private LocalDateTime dateTime;
+    private OffsetDateTime dateTime;
 
     @Lob
     @Column(nullable = false, length = 88)
@@ -54,14 +55,16 @@ public class Diary {
     private List<DiaryImage> diaryImages = new ArrayList<>();
 
     @Column(updatable = false)
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
     @Column(nullable = false)
     private Boolean isStored;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
     }
 
     public void addDiaryImage(DiaryImage image) {
@@ -70,7 +73,7 @@ public class Diary {
     }
 
     public static Diary createDiary(User user, Trip trip, Country country, String city,
-                                   LocalDateTime dateTime, String content) {
+                                   OffsetDateTime dateTime, String content) {
         Diary diary = new Diary();
         diary.setUser(user);
         diary.setTrip(trip);
@@ -78,7 +81,7 @@ public class Diary {
         diary.setCity(city);
         diary.setDateTime(dateTime);
         diary.setContent(content != null ? content : ""); // content는 선택 필드이므로 null인 경우 빈 문자열로 처리
-        diary.setCreatedAt(dateTime != null ? dateTime : LocalDateTime.now());
+        diary.setCreatedAt(dateTime != null ? dateTime : OffsetDateTime.now(ZoneOffset.UTC));
         diary.setIsStored(false);
         return diary;
     }

--- a/src/main/java/zim/tave/memory/domain/Trip.java
+++ b/src/main/java/zim/tave/memory/domain/Trip.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +56,7 @@ public class Trip {
     @PrePersist
     protected void onCreate() {
         if (this.startDate == null) {
-            this.startDate = LocalDate.now();
+            this.startDate = LocalDate.now(ZoneOffset.UTC);
         }
         if (this.endDate == null) {
             this.endDate = this.startDate;
@@ -76,8 +77,8 @@ public class Trip {
         trip.setTripName(tripName);
         trip.setDescription(description);
         trip.setTripTheme(tripTheme);
-        trip.setStartDate(LocalDate.now());
-        trip.setEndDate(LocalDate.now());
+        trip.setStartDate(LocalDate.now(ZoneOffset.UTC));
+        trip.setEndDate(LocalDate.now(ZoneOffset.UTC));
         return trip;
     }
 

--- a/src/main/java/zim/tave/memory/domain/VisitedCountry.java
+++ b/src/main/java/zim/tave/memory/domain/VisitedCountry.java
@@ -20,7 +20,7 @@ public class VisitedCountry {
 
     private String color;
 
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")

--- a/src/main/java/zim/tave/memory/domain/VisitedCountry.java
+++ b/src/main/java/zim/tave/memory/domain/VisitedCountry.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @Entity
 @Getter
@@ -35,6 +36,8 @@ public class VisitedCountry {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
     }
 }

--- a/src/main/java/zim/tave/memory/dto/request/CreateDiaryRequest.java
+++ b/src/main/java/zim/tave/memory/dto/request/CreateDiaryRequest.java
@@ -22,7 +22,6 @@ import java.util.List;
                   "tripId": 1,
                   "countryCode": "KR",
                   "city": "제주시",
-                  "dateTime": "2025-11-30T11:20:01.570Z",
                   "content": "오늘은 제주도에서 멋진 하루를 보냈다.",
                   "images": [
                     {
@@ -55,14 +54,6 @@ public class CreateDiaryRequest {
 
     @Schema(description = "도시명 (필수)", example = "제주시")
     private String city;
-
-    @Schema(
-            description = """
-                    일기 작성 날짜 및 시간 (ISO 8601 형식) : 자동 생성됩니다.
-                    """,
-            example = "2025-11-30T11:20:01.570Z"
-    )
-    private String dateTime;
 
     @Schema(description = "일기 내용", example = "오늘은 제주도에서 멋진 하루를 보냈다.")
     private String content;

--- a/src/main/java/zim/tave/memory/dto/response/BoardCreateResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardCreateResponseDto.java
@@ -1,13 +1,13 @@
 package zim.tave.memory.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zim.tave.memory.domain.Board;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -24,21 +24,21 @@ public class BoardCreateResponseDto {
     @Schema(description = "보드 테마 ID", example = "3")
     private Long boardThemeId;
 
-    @Schema(description = "보드 생성 시각", example = "2025-12-01T14:20:00")
-    private String createdAt;
+    @Schema(description = "보드 생성 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime createdAt;
 
-    @Schema(description = "보드 최종 수정 시각", example = "2025-12-01T14:20:00")
-    private String updatedAt;
+    @Schema(description = "보드 최종 수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime updatedAt;
 
     public static BoardCreateResponseDto from(Board board) {
-        DateTimeFormatter fmt = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
         return new BoardCreateResponseDto(
                 board.getBoardId(),
                 board.getTitle(),
                 board.getBoardTheme().getBoardThemeId(),
-                board.getCreatedAt().format(fmt),
-                board.getUpdatedAt().format(fmt)
+                board.getCreatedAt(),
+                board.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/zim/tave/memory/dto/response/BoardCreateResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardCreateResponseDto.java
@@ -1,6 +1,5 @@
 package zim.tave.memory.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,11 +24,9 @@ public class BoardCreateResponseDto {
     private Long boardThemeId;
 
     @Schema(description = "보드 생성 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime createdAt;
 
     @Schema(description = "보드 최종 수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime updatedAt;
 
     public static BoardCreateResponseDto from(Board board) {

--- a/src/main/java/zim/tave/memory/dto/response/BoardDetailResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardDetailResponseDto.java
@@ -1,6 +1,5 @@
 package zim.tave.memory.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,11 +31,9 @@ public class BoardDetailResponseDto {
     private String thumbnailUrl;
 
     @Schema(description = "생성 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime createdAt;
 
     @Schema(description = "수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T17:30:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime updatedAt;
 
     @Schema(description = "스티커 목록")

--- a/src/main/java/zim/tave/memory/dto/response/BoardDetailResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardDetailResponseDto.java
@@ -1,5 +1,6 @@
 package zim.tave.memory.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,8 +9,7 @@ import lombok.NoArgsConstructor;
 import zim.tave.memory.domain.Board;
 import zim.tave.memory.domain.BoardStickerMap;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
@@ -31,25 +31,25 @@ public class BoardDetailResponseDto {
     @Schema(description = "테마 썸네일 URL")
     private String thumbnailUrl;
 
-    @Schema(description = "생성 시각")
-    private String createdAt;
+    @Schema(description = "생성 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime createdAt;
 
-    @Schema(description = "수정 시각")
-    private String updatedAt;
+    @Schema(description = "수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T17:30:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime updatedAt;
 
     @Schema(description = "스티커 목록")
     private List<BoardStickerDetailDto> stickers;
 
     public static BoardDetailResponseDto from(Board board, List<BoardStickerMap> stickerMaps) {
-        DateTimeFormatter fmt = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
         return BoardDetailResponseDto.builder()
                 .boardId(board.getBoardId())
                 .title(board.getTitle())
                 .boardThemeId(board.getBoardTheme().getBoardThemeId())
                 .thumbnailUrl(board.getBoardTheme().getThumbnailUrl())
-                .createdAt(board.getCreatedAt().format(fmt))
-                .updatedAt(board.getUpdatedAt().format(fmt))
+                .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
                 .stickers(stickerMaps.stream()
                         .map(BoardStickerDetailDto::from)
                         .toList())

--- a/src/main/java/zim/tave/memory/dto/response/BoardInformResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardInformResponseDto.java
@@ -1,12 +1,12 @@
 package zim.tave.memory.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import zim.tave.memory.domain.Board;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
@@ -23,11 +23,13 @@ public class BoardInformResponseDto {
     @Schema(description = "보드 테마 ID", example = "3")
     private Long boardThemeId;
 
-    @Schema(description = "보드 생성 시각", example = "2025-12-01T14:20:00")
-    private String createdAt;
+    @Schema(description = "보드 생성 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime createdAt;
 
-    @Schema(description = "보드 최종 수정 시각", example = "2025-12-01T14:20:00")
-    private String updatedAt;
+    @Schema(description = "보드 최종 수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime updatedAt;
 
     @Schema(description = "보드에 포함된 스티커 개수", example = "3")
     private int stickerCount;
@@ -36,14 +38,12 @@ public class BoardInformResponseDto {
     private List<String> stickerUrls;
 
     public static BoardInformResponseDto from(Board board, List<String> stickerUrls) {
-        DateTimeFormatter fmt = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
         return new BoardInformResponseDto(
                 board.getBoardId(),
                 board.getTitle(),
                 board.getBoardTheme().getBoardThemeId(),
-                board.getCreatedAt().format(fmt),
-                board.getUpdatedAt().format(fmt),
+                board.getCreatedAt(),
+                board.getUpdatedAt(),
                 stickerUrls.size(),
                 stickerUrls
         );

--- a/src/main/java/zim/tave/memory/dto/response/BoardInformResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardInformResponseDto.java
@@ -1,6 +1,5 @@
 package zim.tave.memory.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,11 +23,9 @@ public class BoardInformResponseDto {
     private Long boardThemeId;
 
     @Schema(description = "보드 생성 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime createdAt;
 
     @Schema(description = "보드 최종 수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T14:20:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime updatedAt;
 
     @Schema(description = "보드에 포함된 스티커 개수", example = "3")

--- a/src/main/java/zim/tave/memory/dto/response/BoardUpdateResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardUpdateResponseDto.java
@@ -1,6 +1,5 @@
 package zim.tave.memory.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,7 +20,6 @@ public class BoardUpdateResponseDto {
     private Long boardId;
 
     @Schema(description = "보드 최종 수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T17:30:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime updatedAt;
 
     @Schema(description = "적용된 스티커 리스트")

--- a/src/main/java/zim/tave/memory/dto/response/BoardUpdateResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/BoardUpdateResponseDto.java
@@ -1,5 +1,6 @@
 package zim.tave.memory.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,8 +8,7 @@ import lombok.NoArgsConstructor;
 import zim.tave.memory.domain.Board;
 import zim.tave.memory.domain.BoardStickerMap;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
@@ -20,23 +20,21 @@ public class BoardUpdateResponseDto {
     @Schema(description = "보드 ID", example = "21")
     private Long boardId;
 
-    @Schema(description = "보드 최종 수정 시각", example = "2025-12-01T17:30:00")
-    private String updatedAt;
+    @Schema(description = "보드 최종 수정 시각 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2025-12-01T17:30:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime updatedAt;
 
     @Schema(description = "적용된 스티커 리스트")
     private List<BoardStickerItem> stickers;
 
     public static BoardUpdateResponseDto from(Board board, List<BoardStickerMap> stickerMaps) {
-
-        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
         List<BoardStickerItem> stickerItems = stickerMaps.stream()
                 .map(BoardStickerItem::from)
                 .toList();
 
         return new BoardUpdateResponseDto(
                 board.getBoardId(),
-                board.getUpdatedAt().format(formatter),
+                board.getUpdatedAt(),
                 stickerItems
         );
     }

--- a/src/main/java/zim/tave/memory/dto/response/DiaryResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/DiaryResponseDto.java
@@ -1,6 +1,5 @@
 package zim.tave.memory.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -32,11 +31,9 @@ public class DiaryResponseDto {
 	private final String detailedLocation;
 
 	@Schema(description = "일기 작성 날짜 및 시간 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2024-05-20T10:00:00.000Z")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 	private final OffsetDateTime dateTime;
 
 	@Schema(description = "일기 생성 날짜 및 시간 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2024-05-20T10:00:00.000Z")
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 	private final OffsetDateTime createdAt;
 
 	@Schema(description = "일기 내용", example = "오늘은 제주도에서 멋진 하루를 보냈다.")

--- a/src/main/java/zim/tave/memory/dto/response/DiaryResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/DiaryResponseDto.java
@@ -31,11 +31,11 @@ public class DiaryResponseDto {
 	@Schema(description = "상세 위치", example = "한라산 정상")
 	private final String detailedLocation;
 
-	@Schema(description = "일기 작성 날짜 및 시간", example = "2024-05-20T10:00:00.000Z")
+	@Schema(description = "일기 작성 날짜 및 시간 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2024-05-20T10:00:00.000Z")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 	private final OffsetDateTime dateTime;
 
-	@Schema(description = "일기 생성 날짜 및 시간", example = "2024-05-20T10:00:00.000Z")
+	@Schema(description = "일기 생성 날짜 및 시간 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2024-05-20T10:00:00.000Z")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
 	private final OffsetDateTime createdAt;
 

--- a/src/main/java/zim/tave/memory/dto/response/DiaryResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/DiaryResponseDto.java
@@ -1,12 +1,13 @@
 package zim.tave.memory.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
@@ -30,11 +31,13 @@ public class DiaryResponseDto {
 	@Schema(description = "상세 위치", example = "한라산 정상")
 	private final String detailedLocation;
 
-	@Schema(description = "일기 작성 날짜 및 시간", example = "2025-11-30T11:20:01")
-	private final LocalDateTime dateTime;
+	@Schema(description = "일기 작성 날짜 및 시간", example = "2024-05-20T10:00:00.000Z")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+	private final OffsetDateTime dateTime;
 
-	@Schema(description = "일기 생성 날짜 및 시간", example = "2025-11-30T11:20:01")
-	private final LocalDateTime createdAt;
+	@Schema(description = "일기 생성 날짜 및 시간", example = "2024-05-20T10:00:00.000Z")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+	private final OffsetDateTime createdAt;
 
 	@Schema(description = "일기 내용", example = "오늘은 제주도에서 멋진 하루를 보냈다.")
 	private final String content;

--- a/src/main/java/zim/tave/memory/dto/response/StoredDiaryResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/StoredDiaryResponseDto.java
@@ -1,6 +1,5 @@
 package zim.tave.memory.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +24,6 @@ public class StoredDiaryResponseDto {
     private String representativeImageUrl;
 
     @Schema(description = "일기 작성 날짜 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2024-11-14T18:20:00.000Z")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private OffsetDateTime createdAt;
 
     @Schema(description = "작성 요일", example = "THURSDAY")

--- a/src/main/java/zim/tave/memory/dto/response/StoredDiaryResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/StoredDiaryResponseDto.java
@@ -1,5 +1,6 @@
 package zim.tave.memory.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 import zim.tave.memory.domain.Diary;
 import zim.tave.memory.domain.DiaryImage;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Getter
 @Builder
@@ -23,8 +24,9 @@ public class StoredDiaryResponseDto {
     @Schema(description = "일기 대표 이미지 URL", example = "https://s3.amazonaws.com/images/diary1.jpg")
     private String representativeImageUrl;
 
-    @Schema(description = "일기 작성 날짜", example = "2024-11-14T18:20:00")
-    private LocalDateTime createdAt;
+    @Schema(description = "일기 작성 날짜 (UTC 기준, ISO-8601 형식). 프론트엔드에서는 사용자의 로컬 타임존으로 변환하여 표시해야 합니다.", example = "2024-11-14T18:20:00.000Z")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    private OffsetDateTime createdAt;
 
     @Schema(description = "작성 요일", example = "THURSDAY")
     private String dayOfWeek;
@@ -38,8 +40,8 @@ public class StoredDiaryResponseDto {
                 .findFirst()
                 .orElse(null);
 
-        LocalDateTime created = diary.getCreatedAt();
-        String day = created.getDayOfWeek().name();
+        OffsetDateTime created = diary.getCreatedAt();
+        String day = created.toLocalDateTime().getDayOfWeek().name();
 
         return StoredDiaryResponseDto.builder()
                 .diaryId(diary.getId())

--- a/src/main/java/zim/tave/memory/service/BoardService.java
+++ b/src/main/java/zim/tave/memory/service/BoardService.java
@@ -14,7 +14,8 @@ import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.*;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,8 +48,7 @@ public class BoardService {
         board.setUser(user);
         board.setBoardTheme(theme);
         board.setTitle(requestDto.getTitle());
-        board.setCreatedAt(LocalDateTime.now());
-        board.setUpdatedAt(LocalDateTime.now());
+        // createdAt과 updatedAt은 @PrePersist, @PreUpdate에서 자동 설정됨
 
         Board saved = boardRepository.save(board);
 
@@ -148,7 +148,7 @@ public class BoardService {
         BoardStickerMap saved = boardStickerMapRepository.save(map);
 
         // 보드 업데이트 시간 갱신
-        board.setUpdatedAt(LocalDateTime.now());
+        board.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
 
         return BoardStickerAddResponseDto.from(saved);
     }
@@ -181,7 +181,7 @@ public class BoardService {
         map.setPosY(BigDecimal.valueOf(dto.getPosY()));
         map.setRotation(BigDecimal.valueOf(dto.getRotation()));
 
-        board.setUpdatedAt(LocalDateTime.now());
+        board.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
 
         return BoardStickerUpdateResponseDto.from(map);
     }
@@ -207,7 +207,7 @@ public class BoardService {
 
         boardStickerMapRepository.delete(map);
 
-        board.setUpdatedAt(LocalDateTime.now());
+        board.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
     }
 
 }

--- a/src/main/java/zim/tave/memory/service/DiaryService.java
+++ b/src/main/java/zim/tave/memory/service/DiaryService.java
@@ -13,11 +13,8 @@ import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -35,29 +32,6 @@ public class DiaryService {
 	private final DiaryImageRepository diaryImageRepository;
     private final CountryService countryService;
     private final VisitedCountryService visitedCountryService;
-
-    // 날짜 및 시간 파싱 (ISO 8601 형식 지원)
-    private LocalDateTime parseDateTime(String dateTimeString) {
-        if (dateTimeString == null || dateTimeString.trim().isEmpty()) {
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
-        }
-        
-        String trimmed = dateTimeString.trim();
-        
-        try {
-            // offset 또는 Z 포함 ISO => OffsetDateTime.parse가 대부분 처리
-            OffsetDateTime odt = OffsetDateTime.parse(trimmed);
-            return odt.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
-        } catch (DateTimeParseException ignored) {
-            try {
-                // 타임존 없는 로컬 포맷: yyyy-MM-dd'T'HH:mm:ss[.SSS...]
-                // ISO_LOCAL_DATE_TIME은 0-9자리의 소수점 초를 모두 처리 가능
-                return LocalDateTime.parse(trimmed, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-            } catch (DateTimeParseException e) {
-                throw new CustomException(ErrorCode.VALIDATION_ERROR);
-            }
-        }
-    }
 
     // 이미지 검증&저장
     private void validateAndAttachImages(Diary diary, List<CreateDiaryRequest.DiaryImageInfo> images) {
@@ -108,8 +82,8 @@ public class DiaryService {
         Country country = countryService.findByCode(request.getCountryCode());
         if (country == null) throw new CustomException(ErrorCode.INVALID_COUNTRY_CODE);
 
-        // 날짜 및 시간 파싱 및 검증
-        LocalDateTime dateTime = parseDateTime(request.getDateTime());
+        // 날짜 및 시간 자동 생성 (UTC 기준)
+        OffsetDateTime dateTime = OffsetDateTime.now(ZoneOffset.UTC);
 
         // 감정 검증 (기본 = 1)
         Emotion emotion = emotionRepository.findById(

--- a/src/main/java/zim/tave/memory/service/JoinService.java
+++ b/src/main/java/zim/tave/memory/service/JoinService.java
@@ -10,6 +10,7 @@ import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +39,7 @@ public class JoinService {
         user.setKoreanName(requestDto.getKoreanName());
         user.setBirth(requestDto.getBirth());
         user.setNationality(requestDto.getNationality());
-        user.setCreatedAt(LocalDate.now());
+        user.setCreatedAt(LocalDate.now(ZoneOffset.UTC));
         user.setStatus(true);
         user.setRegistered(true);
 

--- a/src/main/java/zim/tave/memory/service/LoginService.java
+++ b/src/main/java/zim/tave/memory/service/LoginService.java
@@ -14,6 +14,7 @@ import zim.tave.memory.kakao.KakaoUserInfo;
 import zim.tave.memory.repository.UserRepository;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +43,7 @@ public class LoginService {
         User newUser = new User();
         newUser.setKakaoId(kakaoUserInfo.getKakaoId());
         newUser.setProfileImageUrl(kakaoUserInfo.getProfileImageUrl());
-        newUser.setCreatedAt(LocalDate.now());
+        newUser.setCreatedAt(LocalDate.now(ZoneOffset.UTC));
         newUser.setStatus(true);
         newUser.setRegistered(false);
         newUser.setDiaryCount(0L);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     import: optional:application-secret.yml
 
   datasource:
-    url: jdbc:mysql://localhost:3306/memory_db?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:3306/memory_db?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
     username: memory_user
     driver-class-name: com.mysql.cj.jdbc.Driver
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     url: jdbc:mysql://localhost:3306/memory_db?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
     username: memory_user
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jackson:
+    time-zone: UTC
+    serialization:
+      write-dates-as-timestamps: false
+    default-property-inclusion: non_null
   servlet:
     multipart:
       max-file-size: 500MB
@@ -19,6 +24,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: UTC
+        timezone:
+          default_storage: NORMALIZE_UTC
         connection:
           characterEncoding: utf8mb4
           useUnicode: true

--- a/src/test/java/zim/tave/memory/api/ApiTestBase.java
+++ b/src/test/java/zim/tave/memory/api/ApiTestBase.java
@@ -13,7 +13,8 @@ import zim.tave.memory.jwt.JwtUtil;
 import zim.tave.memory.repository.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 /**
  * API 통합 테스트 베이스 클래스
@@ -205,7 +206,7 @@ public abstract class ApiTestBase extends AbstractContainerBaseTest {
     /**
      * 테스트용 일기 생성 헬퍼 메서드
      */
-    protected Diary createTestDiary(Trip trip, String city, LocalDateTime dateTime, String content) {
+    protected Diary createTestDiary(Trip trip, String city, OffsetDateTime dateTime, String content) {
         Diary diary = Diary.createDiary(testUser, trip, koreaCountry, city, dateTime, content);
         diary.setOptionalFields(null, defaultEmotion, sunnyWeather);
         return diaryRepository.save(diary);

--- a/src/test/java/zim/tave/memory/api/RecordingFlowApiTest.java
+++ b/src/test/java/zim/tave/memory/api/RecordingFlowApiTest.java
@@ -57,7 +57,7 @@ public class RecordingFlowApiTest extends ApiTestBase {
         diaryRequest.setTripId(tripId);
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("제주도 첫째 날");
         diaryRequest.setEmotionId(defaultEmotion.getId());
         diaryRequest.setWeatherId(sunnyWeather.getId());
@@ -112,7 +112,7 @@ public class RecordingFlowApiTest extends ApiTestBase {
         firstDiary.setTripId(tripId);
         firstDiary.setCountryCode("KR");
         firstDiary.setCity("제주시");
-        firstDiary.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         firstDiary.setContent("첫째 날");
 
         CreateDiaryRequest.DiaryImageInfo front1 = new CreateDiaryRequest.DiaryImageInfo();
@@ -138,7 +138,7 @@ public class RecordingFlowApiTest extends ApiTestBase {
         secondDiary.setTripId(tripId);
         secondDiary.setCountryCode("KR");
         secondDiary.setCity("서귀포시");
-        secondDiary.setDateTime("2024-01-02T14:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         secondDiary.setContent("둘째 날");
 
         CreateDiaryRequest.DiaryImageInfo front2 = new CreateDiaryRequest.DiaryImageInfo();

--- a/src/test/java/zim/tave/memory/controller/DiaryControllerTest.java
+++ b/src/test/java/zim/tave/memory/controller/DiaryControllerTest.java
@@ -570,8 +570,8 @@ class DiaryControllerTest {
     }
 
     @Test
-    void 일기_생성_dateTime_null_성공() throws Exception {
-        // given - dateTime은 선택 필드(자동 생성)이므로 null이어도 성공해야 함
+    void 일기_생성_dateTime_자동생성_성공() throws Exception {
+        // given - dateTime은 서버에서 자동 생성되므로 요청에 포함하지 않음
         Long userId = 1L;
         setSecurityContext(userId);
 
@@ -579,7 +579,7 @@ class DiaryControllerTest {
         request.setTripId(1L);
         request.setCountryCode("KR");
         request.setCity("서울");
-        request.setDateTime(null); // 선택 필드 null
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         request.setContent("테스트 내용");
 
         // 필수 필드: images

--- a/src/test/java/zim/tave/memory/domain/DiaryTest.java
+++ b/src/test/java/zim/tave/memory/domain/DiaryTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import static org.assertj.core.api.Assertions.*;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 class DiaryTest {
 
@@ -29,7 +30,7 @@ class DiaryTest {
     void 다이어리_생성_테스트() {
         // given
         String city = "서울";
-        LocalDateTime dateTime = LocalDateTime.of(2024, 1, 15, 10, 0);
+        OffsetDateTime dateTime = OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC);
         String content = "서울 여행 첫째 날";
 
         // when
@@ -49,7 +50,7 @@ class DiaryTest {
     void 선택적_필드_설정_테스트() {
         // given
         Diary diary = Diary.createDiary(user, trip, country, "서울", 
-                                       LocalDateTime.now(), "테스트 내용");
+                                       OffsetDateTime.now(ZoneOffset.UTC), "테스트 내용");
         
         String detailedLocation = "강남역 1번 출구";
         Emotion emotion = new Emotion("행복", "#FFD700");
@@ -69,7 +70,7 @@ class DiaryTest {
     void 이미지_추가_테스트() {
         // given
         Diary diary = Diary.createDiary(user, trip, country, "서울", 
-                                       LocalDateTime.now(), "테스트 내용");
+                                       OffsetDateTime.now(ZoneOffset.UTC), "테스트 내용");
         DiaryImage image1 = new DiaryImage();
         image1.setImageUrl("image1.jpg");
         image1.setCameraType(DiaryImage.CameraType.FRONT);

--- a/src/test/java/zim/tave/memory/domain/TripTest.java
+++ b/src/test/java/zim/tave/memory/domain/TripTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 class TripTest {
 
@@ -36,7 +37,7 @@ class TripTest {
         assertThat(trip.getDescription()).isEqualTo(description);
         assertThat(trip.getUser()).isEqualTo(user);
         assertThat(trip.getTripTheme()).isEqualTo(tripTheme);
-        assertThat(trip.getStartDate()).isEqualTo(LocalDate.now());
+        assertThat(trip.getStartDate()).isEqualTo(LocalDate.now(ZoneOffset.UTC));
     }
 
     @Test
@@ -44,7 +45,7 @@ class TripTest {
         // given
         Trip trip = Trip.createTrip(user, "제주도 여행", "제주도 여행", tripTheme);
         Diary diary = new Diary();
-        diary.setCreatedAt(LocalDateTime.of(2024, 1, 15, 10, 0));
+        diary.setCreatedAt(OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));
 
         // when
         trip.addDiary(diary);

--- a/src/test/java/zim/tave/memory/integration/AbstractContainerBaseTest.java
+++ b/src/test/java/zim/tave/memory/integration/AbstractContainerBaseTest.java
@@ -95,7 +95,8 @@ public abstract class AbstractContainerBaseTest {
         
         // Spring Boot의 데이터소스 속성 설정
         // Supplier를 사용하여 런타임에 값을 가져옵니다
-        registry.add("spring.datasource.url", () -> jdbcUrl);
+        // UTC 타임존 설정 추가
+        registry.add("spring.datasource.url", () -> jdbcUrl + (jdbcUrl.contains("?") ? "&serverTimezone=UTC" : "?serverTimezone=UTC"));
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");

--- a/src/test/java/zim/tave/memory/integration/IntegrationTestBase.java
+++ b/src/test/java/zim/tave/memory/integration/IntegrationTestBase.java
@@ -7,7 +7,8 @@ import zim.tave.memory.domain.*;
 import zim.tave.memory.repository.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 /**
  * 통합 테스트 베이스 클래스
@@ -169,7 +170,7 @@ public abstract class IntegrationTestBase extends AbstractContainerBaseTest {
     /**
      * 테스트용 일기 생성 헬퍼 메서드
      */
-    protected Diary createTestDiary(Trip trip, String city, LocalDateTime dateTime, String content) {
+    protected Diary createTestDiary(Trip trip, String city, OffsetDateTime dateTime, String content) {
         Diary diary = Diary.createDiary(testUser, trip, koreaCountry, city, dateTime, content);
         diary.setOptionalFields(null, defaultEmotion, sunnyWeather);
         return diaryRepository.save(diary);

--- a/src/test/java/zim/tave/memory/integration/MyPageIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/MyPageIntegrationTest.java
@@ -12,7 +12,8 @@ import zim.tave.memory.service.VisitedCountryService;
 import zim.tave.memory.repository.VisitedCountryRepository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,8 +110,8 @@ public class MyPageIntegrationTest extends IntegrationTestBase {
         );
 
         // 같은 국가(한국)로 일기 생성
-        createTestDiary(trip1, "제주시", LocalDateTime.now(), "일기 1");
-        createTestDiary(trip2, "서귀포시", LocalDateTime.now(), "일기 2");
+        createTestDiary(trip1, "제주시", OffsetDateTime.now(ZoneOffset.UTC), "일기 1");
+        createTestDiary(trip2, "서귀포시", OffsetDateTime.now(ZoneOffset.UTC), "일기 2");
 
         // 다른 국가 추가
         Country japanCountry = new Country("JP", "일본", "🇯🇵");

--- a/src/test/java/zim/tave/memory/integration/MyPageIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/MyPageIntegrationTest.java
@@ -73,14 +73,14 @@ public class MyPageIntegrationTest extends IntegrationTestBase {
         Diary diary1 = createTestDiary(
             trip,
             "제주시",
-            LocalDateTime.of(2024, 1, 1, 10, 0),
+            OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC),
             "첫 번째 일기"
         );
 
         Diary diary2 = createTestDiary(
             trip,
             "서귀포시",
-            LocalDateTime.of(2024, 1, 2, 14, 0),
+            OffsetDateTime.of(2024, 1, 2, 14, 0, 0, 0, ZoneOffset.UTC),
             "두 번째 일기"
         );
 

--- a/src/test/java/zim/tave/memory/integration/RecordingFlowIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/RecordingFlowIntegrationTest.java
@@ -55,7 +55,7 @@ public class RecordingFlowIntegrationTest extends IntegrationTestBase {
         diaryRequest.setTripId(createdTrip.getId());
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("제주도 첫째 날 - 한라산 등반");
         diaryRequest.setDetailedLocation("한라산 정상");
         diaryRequest.setEmotionId(defaultEmotion.getId());
@@ -115,7 +115,7 @@ public class RecordingFlowIntegrationTest extends IntegrationTestBase {
         firstDiaryRequest.setTripId(existingTrip.getId());
         firstDiaryRequest.setCountryCode("KR");
         firstDiaryRequest.setCity("제주시");
-        firstDiaryRequest.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         firstDiaryRequest.setContent("첫째 날 일기");
         firstDiaryRequest.setEmotionId(defaultEmotion.getId());
         firstDiaryRequest.setWeatherId(sunnyWeather.getId());
@@ -139,7 +139,7 @@ public class RecordingFlowIntegrationTest extends IntegrationTestBase {
         secondDiaryRequest.setTripId(existingTrip.getId());
         secondDiaryRequest.setCountryCode("KR");
         secondDiaryRequest.setCity("서귀포시");
-        secondDiaryRequest.setDateTime("2024-01-02T14:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         secondDiaryRequest.setContent("둘째 날 일기");
         secondDiaryRequest.setEmotionId(defaultEmotion.getId());
         secondDiaryRequest.setWeatherId(sunnyWeather.getId());
@@ -187,7 +187,7 @@ public class RecordingFlowIntegrationTest extends IntegrationTestBase {
         diaryRequest.setTripId(trip.getId());
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("대표사진 테스트");
         diaryRequest.setEmotionId(defaultEmotion.getId());
 
@@ -231,7 +231,7 @@ public class RecordingFlowIntegrationTest extends IntegrationTestBase {
         diaryRequest.setTripId(trip.getId());
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("감정색 기본값 테스트");
         // emotionId를 설정하지 않음 (기본값 사용)
 
@@ -271,7 +271,7 @@ public class RecordingFlowIntegrationTest extends IntegrationTestBase {
         diaryRequest.setTripId(trip.getId());
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-01T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("날씨 선택 안함 테스트");
         diaryRequest.setEmotionId(defaultEmotion.getId());
         // weatherId를 설정하지 않음

--- a/src/test/java/zim/tave/memory/integration/SettingsIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/SettingsIntegrationTest.java
@@ -13,7 +13,8 @@ import zim.tave.memory.service.StorageService;
 import zim.tave.memory.service.TripService;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -61,7 +62,7 @@ public class SettingsIntegrationTest extends IntegrationTestBase {
         testDiary = createTestDiary(
             testTrip,
             "제주시",
-            LocalDateTime.of(2024, 1, 1, 10, 0),
+            OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC),
             "일기 내용"
         );
     }

--- a/src/test/java/zim/tave/memory/integration/TripDiaryIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/TripDiaryIntegrationTest.java
@@ -26,7 +26,8 @@ import zim.tave.memory.service.CountryService;
 import zim.tave.memory.service.VisitedCountryService;
 import zim.tave.memory.dto.response.TripResponseDto;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
@@ -114,7 +115,7 @@ class TripDiaryIntegrationTest {
         diaryRequest.setTripId(1L);
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-15T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("제주도 첫째 날");
 
         CreateDiaryRequest.DiaryImageInfo imageInfo1 = new CreateDiaryRequest.DiaryImageInfo();
@@ -145,7 +146,8 @@ class TripDiaryIntegrationTest {
 
         // then
         assertThat(createdDiary.getTripId()).isEqualTo(trip.getId());
-        assertThat(trip.getEndDate()).isEqualTo(LocalDateTime.parse(diaryRequest.getDateTime()).toLocalDate());
+        // dateTime은 서버에서 자동 생성되므로 createdAt을 기준으로 검증
+        assertThat(trip.getEndDate()).isNotNull();
     }
 
     @Test
@@ -160,7 +162,7 @@ class TripDiaryIntegrationTest {
         diaryRequest1.setTripId(1L);
         diaryRequest1.setCountryCode("KR");
         diaryRequest1.setCity("제주시");
-        diaryRequest1.setDateTime("2024-01-15T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest1.setContent("제주도 첫째 날");
         diaryRequest1.setImages(createImageInfo("front1.jpg", "back1.jpg"));
 
@@ -175,7 +177,7 @@ class TripDiaryIntegrationTest {
         diaryRequest2.setTripId(1L);
         diaryRequest2.setCountryCode("KR");
         diaryRequest2.setCity("서귀포시");
-        diaryRequest2.setDateTime("2024-01-20T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest2.setContent("제주도 마지막 날");
         diaryRequest2.setImages(createImageInfo("front2.jpg", "back2.jpg"));
 
@@ -186,13 +188,13 @@ class TripDiaryIntegrationTest {
         persisted2.setId(2L);
         persisted2.setTrip(trip);
         persisted2.setUser(user);
-        persisted2.setCreatedAt(LocalDateTime.of(2024, 1, 20, 10, 0));
+        persisted2.setCreatedAt(OffsetDateTime.of(2024, 1, 20, 10, 0, 0, 0, ZoneOffset.UTC));
         when(diaryRepository.findById(2L)).thenReturn(Optional.of(persisted2));
         Diary persisted1 = new Diary();
         persisted1.setId(1L);
         persisted1.setTrip(trip);
         persisted1.setUser(user);
-        persisted1.setCreatedAt(LocalDateTime.of(2024, 1, 15, 10, 0));
+        persisted1.setCreatedAt(OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));
         when(diaryRepository.findByTrip_Id(1L)).thenReturn(Arrays.asList(persisted1));
 
         diaryService.deleteDiary(2L, 1L);
@@ -212,7 +214,7 @@ class TripDiaryIntegrationTest {
         diaryRequest.setTripId(1L);
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-15T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("제주도 여행");
         diaryRequest.setImages(createImageInfo("front.jpg", "back.jpg"));
 
@@ -226,7 +228,7 @@ class TripDiaryIntegrationTest {
         persisted.setId(1L);
         persisted.setTrip(trip);
         persisted.setUser(user);
-        persisted.setCreatedAt(LocalDateTime.of(2024, 1, 15, 10, 0));
+        persisted.setCreatedAt(OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));
         when(diaryRepository.findById(1L)).thenReturn(Optional.of(persisted));
         when(diaryRepository.findByTrip_Id(1L)).thenReturn(Arrays.asList());
 
@@ -248,7 +250,7 @@ class TripDiaryIntegrationTest {
         diaryRequest1.setTripId(1L);
         diaryRequest1.setCountryCode("KR");
         diaryRequest1.setCity("제주시");
-        diaryRequest1.setDateTime("2024-01-15T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest1.setContent("제주도 첫째 날");
         diaryRequest1.setImages(createImageInfo("front1.jpg", "back1.jpg"));
 
@@ -264,7 +266,7 @@ class TripDiaryIntegrationTest {
         diaryRequest2.setTripId(1L);
         diaryRequest2.setCountryCode("KR");
         diaryRequest2.setCity("서귀포시");
-        diaryRequest2.setDateTime("2024-01-20T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest2.setContent("제주도 마지막 날");
         diaryRequest2.setImages(createImageInfo("front2.jpg", "back2.jpg"));
 
@@ -275,13 +277,13 @@ class TripDiaryIntegrationTest {
         persisted2.setId(2L);
         persisted2.setTrip(trip);
         persisted2.setUser(user);
-        persisted2.setCreatedAt(LocalDateTime.of(2024, 1, 20, 10, 0));
+        persisted2.setCreatedAt(OffsetDateTime.of(2024, 1, 20, 10, 0, 0, 0, ZoneOffset.UTC));
         when(diaryRepository.findById(2L)).thenReturn(Optional.of(persisted2));
         Diary persisted1 = new Diary();
         persisted1.setId(1L);
         persisted1.setTrip(trip);
         persisted1.setUser(user);
-        persisted1.setCreatedAt(LocalDateTime.of(2024, 1, 15, 10, 0));
+        persisted1.setCreatedAt(OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));
         when(diaryRepository.findByTrip_Id(1L)).thenReturn(Arrays.asList(persisted1));
 
         diaryService.deleteDiary(2L, 1L);
@@ -302,7 +304,7 @@ class TripDiaryIntegrationTest {
         diaryRequest.setTripId(1L);
         diaryRequest.setCountryCode("KR");
         diaryRequest.setCity("제주시");
-        diaryRequest.setDateTime("2024-01-15T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         diaryRequest.setContent("제주도 여행");
         diaryRequest.setImages(createImageInfo("front.jpg", "back.jpg"));
 
@@ -316,7 +318,7 @@ class TripDiaryIntegrationTest {
         persisted.setId(1L);
         persisted.setTrip(trip);
         persisted.setUser(user);
-        persisted.setCreatedAt(LocalDateTime.of(2024, 1, 15, 10, 0));
+        persisted.setCreatedAt(OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));
         when(diaryRepository.findById(1L)).thenReturn(Optional.of(persisted));
         when(diaryRepository.findByTrip_Id(1L)).thenReturn(Arrays.asList());
 
@@ -452,8 +454,8 @@ class TripDiaryIntegrationTest {
             if (diary.getId() == null) {
                 diary.setId(idGenerator.getAndIncrement());
             }
-            if (diary.getCreatedAt() == null && diary.getDateTime() != null) {
-                diary.setCreatedAt(diary.getDateTime());
+            if (diary.getCreatedAt() == null) {
+                diary.setCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
             }
             return diary;
         });

--- a/src/test/java/zim/tave/memory/integration/ViewRecordsFlowIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/ViewRecordsFlowIntegrationTest.java
@@ -10,7 +10,8 @@ import zim.tave.memory.service.DiaryService;
 import zim.tave.memory.service.TripService;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +49,7 @@ public class ViewRecordsFlowIntegrationTest extends IntegrationTestBase {
         testDiary = createTestDiary(
             testTrip,
             "제주시",
-            LocalDateTime.of(2024, 1, 1, 10, 0),
+            OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC),
             "제주도 첫째 날"
         );
 

--- a/src/test/java/zim/tave/memory/service/DiaryServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/DiaryServiceTest.java
@@ -21,15 +21,12 @@ import zim.tave.memory.repository.TripRepository;
 import zim.tave.memory.repository.UserRepository;
 import zim.tave.memory.repository.EmotionRepository;
 import zim.tave.memory.repository.WeatherRepository;
-import java.time.LocalDateTime;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.lang.reflect.Method;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 
 @ExtendWith(MockitoExtension.class)
 class DiaryServiceTest {
@@ -81,7 +78,7 @@ class DiaryServiceTest {
         diary.setTrip(trip);
         diary.setCity("서울");
         diary.setContent("테스트 내용");
-        diary.setCreatedAt(LocalDateTime.of(2024, 1, 15, 10, 0));
+        diary.setCreatedAt(OffsetDateTime.of(2024, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));
         diary.setIsStored(false);
 
         emotion = new Emotion("행복", "#FFD700");
@@ -100,7 +97,7 @@ class DiaryServiceTest {
         request.setTripId(1L);
         request.setCountryCode("KR");
         request.setCity("서울");
-        request.setDateTime("2024-01-15T10:00:00");
+        // dateTime 필드 제거 - 서버에서 UTC 기준으로 자동 생성됨
         request.setContent("테스트 내용");
 
         CreateDiaryRequest.DiaryImageInfo imageInfo1 = new CreateDiaryRequest.DiaryImageInfo();
@@ -231,7 +228,7 @@ class DiaryServiceTest {
     void 다이어리_삭제_후_남은_다이어리_있을_때_종료날짜_업데이트_테스트() {
         // given
         Diary remainingDiary = new Diary();
-        remainingDiary.setCreatedAt(LocalDateTime.of(2024, 1, 20, 10, 0));
+        remainingDiary.setCreatedAt(OffsetDateTime.of(2024, 1, 20, 10, 0, 0, 0, ZoneOffset.UTC));
 
         when(diaryRepository.findById(1L)).thenReturn(Optional.of(diary));
         when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
@@ -409,241 +406,7 @@ class DiaryServiceTest {
     }
 
     @Test
-    void 날짜시간_파싱_Z로_끝나는_ISO8601_포맷_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - Z로 끝나는 포맷
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.570Z");
-        assertThat(result1).isNotNull();
-        
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2024-01-15T10:00:00.000Z");
-        assertThat(result2).isNotNull();
-        assertThat(result2.getYear()).isEqualTo(2024);
-        assertThat(result2.getMonthValue()).isEqualTo(1);
-        assertThat(result2.getDayOfMonth()).isEqualTo(15);
-    }
-
-    @Test
-    void 날짜시간_파싱_Offset_포함_포맷_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - +09:00 (한국 시간)
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01+09:00");
-        assertThat(result1).isNotNull();
-        
-        // when & then - -05:00 (미국 동부 시간)
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01-05:00");
-        assertThat(result2).isNotNull();
-        
-        // when & then - +00:00 (UTC)
-        LocalDateTime result3 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01+00:00");
-        assertThat(result3).isNotNull();
-        
-        // when & then - 밀리초와 offset 함께
-        LocalDateTime result4 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.123+09:00");
-        assertThat(result4).isNotNull();
-    }
-
-    @Test
-    void 날짜시간_파싱_밀리초_포함_포맷_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - 3자리 밀리초
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.123");
-        assertThat(result1).isNotNull();
-        assertThat(result1.getNano()).isEqualTo(123000000);
-        
-        // when & then - 1자리 밀리초
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.1");
-        assertThat(result2).isNotNull();
-        
-        // when & then - 2자리 밀리초
-        LocalDateTime result3 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.12");
-        assertThat(result3).isNotNull();
-        
-        // when & then - 6자리 밀리초 (나노초까지)
-        LocalDateTime result4 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.123456");
-        assertThat(result4).isNotNull();
-    }
-
-    @Test
-    void 날짜시간_파싱_기본_형식_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - 기본 형식 (밀리초 없음)
-        LocalDateTime result = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01");
-        assertThat(result).isNotNull();
-        assertThat(result.getYear()).isEqualTo(2025);
-        assertThat(result.getMonthValue()).isEqualTo(11);
-        assertThat(result.getDayOfMonth()).isEqualTo(30);
-        assertThat(result.getHour()).isEqualTo(11);
-        assertThat(result.getMinute()).isEqualTo(20);
-        assertThat(result.getSecond()).isEqualTo(1);
-    }
-
-    @Test
-    void 날짜시간_파싱_공백_제거_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - 앞뒤 공백 제거
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "  2025-11-30T11:20:01  ");
-        assertThat(result1).isNotNull();
-        
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01");
-        assertThat(result1).isEqualTo(result2);
-    }
-
-    @Test
-    void 날짜시간_파싱_null_또는_빈문자열_예외_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - null
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, (String) null))
-                .hasCauseInstanceOf(CustomException.class);
-        
-        // when & then - 빈 문자열
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, ""))
-                .hasCauseInstanceOf(CustomException.class);
-        
-        // when & then - 공백만 있는 문자열
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, "   "))
-                .hasCauseInstanceOf(CustomException.class);
-    }
-
-    @Test
-    void 날짜시간_파싱_잘못된_형식_예외_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - 잘못된 형식들
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, "2025-11-30"))
-                .hasCauseInstanceOf(CustomException.class);
-        
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, "2025/11/30 11:20:01"))
-                .hasCauseInstanceOf(CustomException.class);
-        
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, "invalid-date"))
-                .hasCauseInstanceOf(CustomException.class);
-        
-        assertThatThrownBy(() -> parseDateTime.invoke(diaryService, "2025-13-45T25:70:99"))
-                .hasCauseInstanceOf(CustomException.class);
-    }
-
-    @Test
-    void 날짜시간_파싱_다양한_실제_사용_시나리오_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - JavaScript Date.toISOString() 결과 (Z 포함)
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2024-12-25T15:30:45.789Z");
-        assertThat(result1).isNotNull();
-        
-        // when & then - 모바일 앱에서 보낼 수 있는 offset 형식
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2024-12-25T15:30:45+09:00");
-        assertThat(result2).isNotNull();
-        
-        // when & then - 서버에서 생성한 로컬 시간
-        LocalDateTime result3 = (LocalDateTime) parseDateTime.invoke(diaryService, "2024-12-25T15:30:45");
-        assertThat(result3).isNotNull();
-        
-        // when & then - 밀리초 포함 로컬 시간
-        LocalDateTime result4 = (LocalDateTime) parseDateTime.invoke(diaryService, "2024-12-25T15:30:45.123");
-        assertThat(result4).isNotNull();
-    }
-
-    @Test
-    void 날짜시간_파싱_Edge_Case_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - 자정
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-01-01T00:00:00");
-        assertThat(result1).isNotNull();
-        assertThat(result1.getHour()).isZero();
-        assertThat(result1.getMinute()).isZero();
-        assertThat(result1.getSecond()).isZero();
-        
-        // when & then - 23:59:59
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-12-31T23:59:59");
-        assertThat(result2).isNotNull();
-        assertThat(result2.getHour()).isEqualTo(23);
-        assertThat(result2.getMinute()).isEqualTo(59);
-        assertThat(result2.getSecond()).isEqualTo(59);
-        
-        // when & then - 윤년 2월 29일
-        LocalDateTime result3 = (LocalDateTime) parseDateTime.invoke(diaryService, "2024-02-29T12:00:00");
-        assertThat(result3).isNotNull();
-        assertThat(result3.getMonthValue()).isEqualTo(2);
-        assertThat(result3.getDayOfMonth()).isEqualTo(29);
-    }
-
-    @Test
-    void 날짜시간_파싱_다양한_밀리초_자릿수_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - 1자리 밀리초
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.1");
-        assertThat(result1).isNotNull();
-        
-        // when & then - 2자리 밀리초
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.12");
-        assertThat(result2).isNotNull();
-        
-        // when & then - 3자리 밀리초
-        LocalDateTime result3 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.123");
-        assertThat(result3).isNotNull();
-        
-        // when & then - 4자리 밀리초
-        LocalDateTime result4 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.1234");
-        assertThat(result4).isNotNull();
-        
-        // when & then - 5자리 밀리초
-        LocalDateTime result5 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.12345");
-        assertThat(result5).isNotNull();
-        
-        // when & then - 6자리 밀리초
-        LocalDateTime result6 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.123456");
-        assertThat(result6).isNotNull();
-    }
-
-    @Test
-    void 날짜시간_파싱_Offset과_밀리초_조합_테스트() throws Exception {
-        // given
-        Method parseDateTime = DiaryService.class.getDeclaredMethod("parseDateTime", String.class);
-        parseDateTime.setAccessible(true);
-        
-        // when & then - Z와 밀리초
-        LocalDateTime result1 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.123Z");
-        assertThat(result1).isNotNull();
-        
-        // when & then - +09:00와 밀리초
-        LocalDateTime result2 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.456+09:00");
-        assertThat(result2).isNotNull();
-        
-        // when & then - -05:00와 밀리초
-        LocalDateTime result3 = (LocalDateTime) parseDateTime.invoke(diaryService, "2025-11-30T11:20:01.789-05:00");
-        assertThat(result3).isNotNull();
-    }
-
-    @Test
-    void 날짜시간_파싱_실제_다이어리_생성_통합_테스트() {
+    void 다이어리_생성_UTC_자동생성_테스트() {
         // given
         CreateDiaryRequest request = new CreateDiaryRequest();
         request.setUserId(1L);
@@ -679,28 +442,14 @@ class DiaryServiceTest {
             return saved;
         });
         
-        // when & then - Z 포맷으로 다이어리 생성
-        request.setDateTime("2025-11-30T11:20:01.570Z");
-        DiaryResponseDto result1 = diaryService.createDiary(request);
-        assertThat(result1).isNotNull();
-        assertThat(result1.getDateTime()).isNotNull();
+        // when - dateTime 필드 없이 다이어리 생성 (서버에서 UTC 기준으로 자동 생성)
+        DiaryResponseDto result = diaryService.createDiary(request);
         
-        // when & then - Offset 포맷으로 다이어리 생성
-        request.setDateTime("2025-11-30T11:20:01+09:00");
-        DiaryResponseDto result2 = diaryService.createDiary(request);
-        assertThat(result2).isNotNull();
-        assertThat(result2.getDateTime()).isNotNull();
-        
-        // when & then - 밀리초 포함 포맷으로 다이어리 생성
-        request.setDateTime("2025-11-30T11:20:01.123");
-        DiaryResponseDto result3 = diaryService.createDiary(request);
-        assertThat(result3).isNotNull();
-        assertThat(result3.getDateTime()).isNotNull();
-        
-        // when & then - 기본 포맷으로 다이어리 생성
-        request.setDateTime("2025-11-30T11:20:01");
-        DiaryResponseDto result4 = diaryService.createDiary(request);
-        assertThat(result4).isNotNull();
-        assertThat(result4.getDateTime()).isNotNull();
+        // then - 서버에서 UTC 기준으로 자동 생성된 시간 확인
+        assertThat(result).isNotNull();
+        assertThat(result.getDateTime()).isNotNull();
+        assertThat(result.getDateTime().getOffset()).isEqualTo(ZoneOffset.UTC);
+        assertThat(result.getCreatedAt()).isNotNull();
+        assertThat(result.getCreatedAt().getOffset()).isEqualTo(ZoneOffset.UTC);
     }
 }

--- a/src/test/java/zim/tave/memory/service/TimelineServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/TimelineServiceTest.java
@@ -20,7 +20,8 @@ import zim.tave.memory.repository.EmotionRepository;
 import zim.tave.memory.repository.TripRepository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -92,10 +93,10 @@ class TimelineServiceTest {
         activeDiary.setTrip(activeTrip);
         activeDiary.setCountry(country);
         activeDiary.setCity("제주시");
-        activeDiary.setDateTime(LocalDateTime.of(2024, 1, 2, 10, 0));
+        activeDiary.setDateTime(OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC));
         activeDiary.setContent("제주도 일기 내용");
         activeDiary.setIsStored(false);
-        activeDiary.setCreatedAt(LocalDateTime.of(2024, 1, 2, 10, 0));
+        activeDiary.setCreatedAt(OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC));
         activeDiary.setEmotion(emotion);
         activeDiary.setDiaryImages(new ArrayList<>());
 
@@ -106,10 +107,10 @@ class TimelineServiceTest {
         storedDiary.setTrip(activeTrip);
         storedDiary.setCountry(country);
         storedDiary.setCity("서귀포시");
-        storedDiary.setDateTime(LocalDateTime.of(2024, 1, 3, 10, 0));
+        storedDiary.setDateTime(OffsetDateTime.of(2024, 1, 3, 10, 0, 0, 0, ZoneOffset.UTC));
         storedDiary.setContent("보관된 일기 내용");
         storedDiary.setIsStored(true);
-        storedDiary.setCreatedAt(LocalDateTime.of(2024, 1, 3, 10, 0));
+        storedDiary.setCreatedAt(OffsetDateTime.of(2024, 1, 3, 10, 0, 0, 0, ZoneOffset.UTC));
         storedDiary.setDiaryImages(new ArrayList<>());
     }
 
@@ -231,10 +232,10 @@ class TimelineServiceTest {
         diary2.setTrip(activeTrip);
         diary2.setCountry(country2);
         diary2.setCity("뉴욕");
-        diary2.setDateTime(LocalDateTime.of(2024, 1, 4, 10, 0));
+        diary2.setDateTime(OffsetDateTime.of(2024, 1, 4, 10, 0, 0, 0, ZoneOffset.UTC));
         diary2.setContent("미국 일기");
         diary2.setIsStored(false);
-        diary2.setCreatedAt(LocalDateTime.of(2024, 1, 4, 10, 0));
+        diary2.setCreatedAt(OffsetDateTime.of(2024, 1, 4, 10, 0, 0, 0, ZoneOffset.UTC));
         diary2.setDiaryImages(new ArrayList<>());
 
         activeTrip.setDiaries(Arrays.asList(activeDiary, diary2));
@@ -352,10 +353,10 @@ class TimelineServiceTest {
         diary1.setTrip(activeTrip);
         diary1.setCountry(country);
         diary1.setCity("제주시");
-        diary1.setDateTime(LocalDateTime.of(2024, 1, 2, 10, 0));
+        diary1.setDateTime(OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC));
         diary1.setContent("첫 번째 일기");
         diary1.setIsStored(false);
-        diary1.setCreatedAt(LocalDateTime.of(2024, 1, 2, 10, 0));
+        diary1.setCreatedAt(OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC));
         diary1.setEmotion(emotion); // 설렘
         diary1.setDiaryImages(new ArrayList<>());
 
@@ -365,10 +366,10 @@ class TimelineServiceTest {
         diary2.setTrip(activeTrip);
         diary2.setCountry(country);
         diary2.setCity("서귀포시");
-        diary2.setDateTime(LocalDateTime.of(2024, 1, 3, 10, 0));
+        diary2.setDateTime(OffsetDateTime.of(2024, 1, 3, 10, 0, 0, 0, ZoneOffset.UTC));
         diary2.setContent("두 번째 일기");
         diary2.setIsStored(false);
-        diary2.setCreatedAt(LocalDateTime.of(2024, 1, 4, 10, 0)); // 더 최근
+        diary2.setCreatedAt(OffsetDateTime.of(2024, 1, 4, 10, 0, 0, 0, ZoneOffset.UTC)); // 더 최근
         diary2.setEmotion(emotion2); // 행복
         diary2.setDiaryImages(new ArrayList<>());
 
@@ -403,10 +404,10 @@ class TimelineServiceTest {
         diaryWithoutEmotion.setTrip(activeTrip);
         diaryWithoutEmotion.setCountry(country);
         diaryWithoutEmotion.setCity("제주시");
-        diaryWithoutEmotion.setDateTime(LocalDateTime.of(2024, 1, 2, 10, 0));
+        diaryWithoutEmotion.setDateTime(OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC));
         diaryWithoutEmotion.setContent("감정 없는 일기");
         diaryWithoutEmotion.setIsStored(false);
-        diaryWithoutEmotion.setCreatedAt(LocalDateTime.of(2024, 1, 2, 10, 0));
+        diaryWithoutEmotion.setCreatedAt(OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC));
         diaryWithoutEmotion.setEmotion(null);
         diaryWithoutEmotion.setDiaryImages(new ArrayList<>());
 


### PR DESCRIPTION
## 🔗 Related Issue
- #66 

## 📝 Description
>  UTC 마이그레이션: Back-end는 절대 시간(UTC), Front-end는 상대 시간(Local) 원칙 도입

### 기획 배경 및 비즈니스 문제
- 글로벌 서비스 확장 대비: 현재 프로젝트가 한국 시간(KST)에 종속되어 있어, 글로벌 서비스 확장 시 데이터 정합성 문제가 발생할 수 있습니다.
- 데이터 신뢰성 향상: 클라이언트가 임의로 생성 시간을 조작하는 것을 방지하고, 서버 호스팅 지역(IDC)의 시스템 시간 설정과 무관하게 일관된 서비스 운영이 필요합니다.
- API 문서화 개선: 프론트엔드 개발자가 UTC 시간을 로컬 타임존으로 변환해야 한다는 점을 명확히 인지할 수 있도록 Swagger 문서에 가이드를 추가합니다.

## 🛠 Changes
### DTO & 도메인 타입 변경 (테스트 코드에도 반영)
 LocalDateTime createdAt → OffsetDateTime createdAt으로 변경하여 UTC 정보 손실 방지

#### API 문서화 개선
Swagger Schema 업데이트: 모든 OffsetDateTime 필드에 다음 정보 추가
UTC 기준 명시
ISO-8601 형식 명시
프론트엔드 변환 가이드 포함
예시에 "Z" 포함 (예: "2024-05-20T10:00:00.000Z")
#### JSON 직렬화 설정
@JsonFormat 어노테이션 추가: ISO-8601 형식(yyyy-MM-dd'T'HH:mm:ss.SSSXXX)으로 직렬화하여 UTC 정보 포함

## ✅ Test Checklist
- 컴파일 및 빌드
- [x] gradlew compileJava 성공 확인
- [x] Linter 에러 없음 확인
- 기존 테스트 검증
- [x] DiaryServiceTest.다이어리_생성_UTC_자동생성_테스트() 확인 - 이미 OffsetDateTime 검증 로직 포함
- [x] 관련 테스트 코드에서 OffsetDateTime 사용 확인 (수정 불필요)
- API 응답 형식 검증
- [x] Swagger 문서에서 UTC 표준 명시 및 프론트엔드 변환 가이드 확인
- [x] 응답 예시에 "Z" 포함 확인 (ISO-8601 형식)
- 데이터 정합성
- [x] Diary, Board, VisitedCountry 엔티티의 @PrePersist에서 OffsetDateTime.now(ZoneOffset.UTC) 사용 확인
- [x] application.yml에서 serverTimezone=UTC 설정 확인