### PR TITLE
Refactor/68 self invocation

### DIFF
--- a/src/main/java/zim/tave/memory/service/TripService.java
+++ b/src/main/java/zim/tave/memory/service/TripService.java
@@ -1,6 +1,8 @@
 package zim.tave.memory.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zim.tave.memory.domain.*;
@@ -27,7 +29,12 @@ public class TripService {
     private final UserRepository userRepository;
     private final VisitedCountryService visitedCountryService;
     private final DiaryRepository diaryRepository;
-    private final TripService self; // self-injection 추가
+
+    private TripService self; // self-injection 추가
+    @Autowired
+    public void setSelf(@Lazy TripService self) {
+        this.self = self;
+    }
 
     @Transactional
     public TripResponseDto createTrip(CreateTripRequest request, Long userId) {

--- a/src/main/java/zim/tave/memory/service/TripService.java
+++ b/src/main/java/zim/tave/memory/service/TripService.java
@@ -238,6 +238,16 @@ public class TripService {
         return buildTripResponseDto(trip);
     }
 
+    /**
+     * 여행 대표 이미지를 소유권 검증 후 업데이트합니다.
+     *
+     * @param tripId 여행 ID
+     * @param imageId 이미지 ID
+     * @param userId 사용자 ID
+     * @throws CustomException 이미지 ID가 null이거나 소유권이 없는 경우
+     *
+     * @implNote self.updateTripRepresentativeImage()를 호출하여 Spring 프록시를 통한 트랜잭션 처리를 보장
+     */
     @Transactional
     public void updateTripRepresentativeImageWithOwnershipCheck(Long tripId, Long imageId, Long userId) {
         if (imageId == null) {
@@ -368,6 +378,7 @@ public class TripService {
      * @param userId 사용자 ID
      * @param isStored 보관 여부
      * @throws CustomException 과거 여행이 아니면 NOT_PAST_TRIP 예외 발생
+     * @implNote self.storeTrip()을 호출하여 트랜잭션 프록시를 통해 일관된 트랜잭션 관리 보장
      */
     @Transactional
     public void storePastTrip(Long tripId, Long userId, boolean isStored) {

--- a/src/main/java/zim/tave/memory/service/TripService.java
+++ b/src/main/java/zim/tave/memory/service/TripService.java
@@ -27,6 +27,7 @@ public class TripService {
     private final UserRepository userRepository;
     private final VisitedCountryService visitedCountryService;
     private final DiaryRepository diaryRepository;
+    private final TripService self; // self-injection 추가
 
     @Transactional
     public TripResponseDto createTrip(CreateTripRequest request, Long userId) {
@@ -120,19 +121,19 @@ public class TripService {
         if (request.getDescription() != null && request.getDescription().trim().length() > 56) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
-        
+
         // 날짜 검증: 하나의 날짜만 수정되더라도 기존 날짜와 비교 검증
         LocalDate existingStartDate = findTrip.getStartDate();
         LocalDate existingEndDate = findTrip.getEndDate();
-        
+
         // DB 제약에 의해 null이 아니어야 하지만, 데이터 무결성 검증
         if (existingStartDate == null || existingEndDate == null) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
-        
+
         LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : existingStartDate;
         LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : existingEndDate;
-        
+
         if (newStartDate.isAfter(newEndDate)) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
@@ -233,7 +234,7 @@ public class TripService {
             throw new CustomException(ErrorCode.IMAGE_ID_REQUIRED);
         }
         validateOwnership(tripId, userId);
-        updateTripRepresentativeImage(tripId, imageId);
+        self.updateTripRepresentativeImage(tripId, imageId);
     }
 
     // DiaryImage ID로 DiaryImage 찾기
@@ -320,19 +321,19 @@ public class TripService {
         if (request.getDescription() != null && request.getDescription().trim().length() > 56) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
-        
+
         // 날짜 검증: 하나의 날짜만 수정되더라도 기존 날짜와 비교 검증
         LocalDate existingStartDate = trip.getStartDate();
         LocalDate existingEndDate = trip.getEndDate();
-        
+
         // DB 제약에 의해 null이 아니어야 하지만, 데이터 무결성 검증
         if (existingStartDate == null || existingEndDate == null) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
-        
+
         LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : existingStartDate;
         LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : existingEndDate;
-        
+
         if (newStartDate.isAfter(newEndDate)) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
@@ -383,7 +384,7 @@ public class TripService {
         }
 
         validateIsPastTrip(trip);
-        storeTrip(tripId, userId, isStored);
+        self.storeTrip(tripId, userId, isStored);
     }
 
     /**

--- a/src/main/java/zim/tave/memory/service/TripService.java
+++ b/src/main/java/zim/tave/memory/service/TripService.java
@@ -122,21 +122,7 @@ public class TripService {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
 
-        // 날짜 검증: 하나의 날짜만 수정되더라도 기존 날짜와 비교 검증
-        LocalDate existingStartDate = findTrip.getStartDate();
-        LocalDate existingEndDate = findTrip.getEndDate();
-
-        // DB 제약에 의해 null이 아니어야 하지만, 데이터 무결성 검증
-        if (existingStartDate == null || existingEndDate == null) {
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
-        }
-
-        LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : existingStartDate;
-        LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : existingEndDate;
-
-        if (newStartDate.isAfter(newEndDate)) {
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
-        }
+        validateUpdatedDates(findTrip, request);
 
         if (request.getTripName() != null) {
             findTrip.setTripName(request.getTripName());
@@ -162,6 +148,23 @@ public class TripService {
 
         if (request.getEndDate() != null) {
             findTrip.setEndDate(request.getEndDate());
+        }
+    }
+
+    // 날짜 검증
+    private void validateUpdatedDates(Trip trip, UpdateTripRequest request) {
+        LocalDate existingStartDate = trip.getStartDate();
+        LocalDate existingEndDate = trip.getEndDate();
+
+        if (existingStartDate == null || existingEndDate == null) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+        }
+
+        LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : existingStartDate;
+        LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : existingEndDate;
+
+        if (newStartDate.isAfter(newEndDate)) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
     }
 

--- a/src/main/java/zim/tave/memory/service/TripService.java
+++ b/src/main/java/zim/tave/memory/service/TripService.java
@@ -325,21 +325,7 @@ public class TripService {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
         }
 
-        // 날짜 검증: 하나의 날짜만 수정되더라도 기존 날짜와 비교 검증
-        LocalDate existingStartDate = trip.getStartDate();
-        LocalDate existingEndDate = trip.getEndDate();
-
-        // DB 제약에 의해 null이 아니어야 하지만, 데이터 무결성 검증
-        if (existingStartDate == null || existingEndDate == null) {
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
-        }
-
-        LocalDate newStartDate = request.getStartDate() != null ? request.getStartDate() : existingStartDate;
-        LocalDate newEndDate = request.getEndDate() != null ? request.getEndDate() : existingEndDate;
-
-        if (newStartDate.isAfter(newEndDate)) {
-            throw new CustomException(ErrorCode.VALIDATION_ERROR);
-        }
+        validateUpdatedDates(trip, request);
 
         if (request.getTripName() != null) {
             trip.setTripName(request.getTripName());

--- a/src/test/java/zim/tave/memory/service/TripServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/TripServiceTest.java
@@ -75,6 +75,8 @@ class TripServiceTest {
         trip.setTripTheme(tripTheme);
         trip.setStartDate(LocalDate.of(2024, 1, 1));
         trip.setEndDate(LocalDate.of(2024, 1, 5));
+
+        tripService.setSelf(tripService);
     }
 
     @Test
@@ -412,4 +414,102 @@ class TripServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TRIP_UPDATE_FORBIDDEN);
     }
+
+    @Test
+    void 날짜_검증_시작날짜가_null인_경우() {
+        // given
+        trip.setStartDate(null);
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setEndDate(LocalDate.of(2024, 2, 1));
+
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+
+        // when & then
+        assertThatThrownBy(() -> tripService.updateTrip(1L, request, 1L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VALIDATION_ERROR);
+    }
+
+    @Test
+    void 날짜_검증_종료날짜가_null인_경우() {
+        // given
+        trip.setEndDate(null);
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setStartDate(LocalDate.of(2024, 2, 1));
+
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+
+        // when & then
+        assertThatThrownBy(() -> tripService.updateTrip(1L, request, 1L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VALIDATION_ERROR);
+    }
+
+    @Test
+    void 날짜_검증_시작날짜만_업데이트() {
+        // given
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setStartDate(LocalDate.of(2024, 1, 2));
+        // endDate는 null (기존 값 유지)
+
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+
+        // when
+        tripService.updateTrip(1L, request, 1L);
+
+        // then
+        assertThat(trip.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 2));
+        assertThat(trip.getEndDate()).isEqualTo(LocalDate.of(2024, 1, 5)); // 기존 값 유지
+    }
+
+    @Test
+    void 날짜_검증_종료날짜만_업데이트() {
+        // given
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setEndDate(LocalDate.of(2024, 1, 10));
+        // startDate는 null (기존 값 유지)
+
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+
+        // when
+        tripService.updateTrip(1L, request, 1L);
+
+        // then
+        assertThat(trip.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1)); // 기존 값 유지
+        assertThat(trip.getEndDate()).isEqualTo(LocalDate.of(2024, 1, 10));
+    }
+
+    @Test
+    void 날짜_검증_시작종료_날짜_동일() {
+        // given
+        UpdateTripRequest request = new UpdateTripRequest();
+        request.setStartDate(LocalDate.of(2024, 1, 5));
+        request.setEndDate(LocalDate.of(2024, 1, 5));
+
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+
+        // when
+        tripService.updateTrip(1L, request, 1L);
+
+        // then
+        assertThat(trip.getStartDate()).isEqualTo(LocalDate.of(2024, 1, 5));
+        assertThat(trip.getEndDate()).isEqualTo(LocalDate.of(2024, 1, 5));
+    }
+
+    @Test
+    void 과거_여행_보관_시_self_트랜잭션_호출() {
+        // given
+        trip.setIsPast(true);
+        TripService spyService = spy(tripService);
+        spyService.setSelf(spyService);
+
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+
+        // when
+        spyService.storePastTrip(1L, 1L, true);
+
+        // then
+        verify(spyService).storeTrip(1L, 1L, true); // self를 통해 호출되었는지 확인
+    }
+
 }


### PR DESCRIPTION
## 🔗 Related Issue
- #68 

## 📝 Description
> 무엇을(What), 왜(Why) 변경했는지 설명합니다.

### 기획 배경 및 비즈니스 문제
- SonarCloud에서 TripService의 `@Transactional` 메서드들이 내부 호출(`this`)로 호출되어 트랜잭션 프록시가 동작하지 않는 문제를 발견했습니다.
- 또한 `updateTrip()`과 `updatePastTrip()` 메서드의 Cognitive Complexity가 16으로 허용치(15)를 초과하여 코드 가독성과 유지보수성이 저하되는 문제가 있었습니다.

### 해결 방법
1. **@Transactional Self-Invocation 문제 해결**: Self-injection 패턴을 적용하여 `@Transactional` 메서드를 프록시를 통해 호출하도록 변경했습니다.
2. **Cognitive Complexity 감소**: 날짜 검증 로직을 `validateUpdatedDates()` 메서드로 추출하여 복잡도를 16에서 12로 감소시켰습니다.
3. **순환 참조 문제 해결**: Setter 주입 방식과 `@Lazy` 어노테이션을 사용하여 순환 참조를 해결했습니다.

## 🛠 Changes
> 핵심 변경 사항을 요약합니다.

- **Self-injection 적용**: `TripService`에 setter 주입으로 자기 자신을 주입받도록 수정
  - `updateTripRepresentativeImageWithOwnershipCheck()` 메서드에서 `self.updateTripRepresentativeImage()` 호출
  - `storePastTrip()` 메서드에서 `self.storeTrip()` 호출
- **날짜 검증 로직 분리**: `validateUpdatedDates()` private 메서드 추가
  - `updateTrip()`과 `updatePastTrip()` 메서드에서 중복된 날짜 검증 로직을 공통 메서드로 추출
  - Cognitive Complexity: 16 → 12 감소
- **순환 참조 해결**: `@Lazy`와 setter 주입으로 순환 참조 문제 해결

## ✅ Test Checklist
> 변경 사항이 정상적으로 동작하는지 확인하기 위해 수행한 테스트 목록입니다.

- [x] 애플리케이션이 정상적으로 구동되는지 확인
- [x] SonarCloud의 코드 품질 이슈가 해결되었는지 확인
- [x] 트랜잭션이 정상적으로 동작하는지 확인
- [ ] 단위 테스트(Unit Test)를 작성하고 통과했나요?
- [ ] 여행 수정/보관/삭제 API가 기존과 동일하게 동작하는지 확인했나요?