### PR TITLE
Fix/73 swagger fixed dto

### DIFF
--- a/src/main/java/zim/tave/memory/config/OpenApiConfig.java
+++ b/src/main/java/zim/tave/memory/config/OpenApiConfig.java
@@ -36,6 +36,12 @@ public class OpenApiConfig {
     @Bean
     public OpenApiCustomizer apiResponseDtoVoidSchemaCustomizer() {
         return openApi -> {
+
+            // Components가 null일 경우 NPE 방지
+            if (openApi.getComponents() == null) {
+                openApi.setComponents(new Components());
+            }
+            
             // ApiResponseDto<Void> 스키마를 명시적으로 등록
             Schema<?> voidSchema = new Schema<>();
             voidSchema.setType("object");
@@ -56,6 +62,13 @@ public class OpenApiConfig {
             dataSchema.setNullable(true);
             dataSchema.setDescription("데이터 (에러 응답에서는 항상 null)");
             voidSchema.addProperty("data", dataSchema);
+
+            // addProperty 사용 제거 → Map + setProperties 방식으로 안전하게 설정
+            Map<String, Schema<?>> properties = new LinkedHashMap<>();
+            properties.put("code", codeSchema);
+            properties.put("message", messageSchema);
+            properties.put("data", dataSchema);
+            voidSchema.setProperties(properties);
             
             // 스키마 등록
             openApi.getComponents().addSchemas("ApiResponseDtoVoid", voidSchema);

--- a/src/main/java/zim/tave/memory/config/OpenApiConfig.java
+++ b/src/main/java/zim/tave/memory/config/OpenApiConfig.java
@@ -6,6 +6,9 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -29,4 +32,33 @@ import org.springframework.context.annotation.Configuration;
     in = SecuritySchemeIn.HEADER
 )
 public class OpenApiConfig {
+
+    @Bean
+    public OpenApiCustomizer apiResponseDtoVoidSchemaCustomizer() {
+        return openApi -> {
+            // ApiResponseDto<Void> 스키마를 명시적으로 등록
+            Schema<?> voidSchema = new Schema<>();
+            voidSchema.setType("object");
+            voidSchema.setDescription("공통 응답 형식 (에러 응답용 - data 필드는 null)");
+            
+            Schema<?> codeSchema = new Schema<>();
+            codeSchema.setType("integer");
+            codeSchema.setDescription("응답 코드");
+            voidSchema.addProperty("code", codeSchema);
+            
+            Schema<?> messageSchema = new Schema<>();
+            messageSchema.setType("string");
+            messageSchema.setDescription("응답 메시지");
+            voidSchema.addProperty("message", messageSchema);
+            
+            Schema<?> dataSchema = new Schema<>();
+            dataSchema.setType("object");
+            dataSchema.setNullable(true);
+            dataSchema.setDescription("데이터 (에러 응답에서는 항상 null)");
+            voidSchema.addProperty("data", dataSchema);
+            
+            // 스키마 등록
+            openApi.getComponents().addSchemas("ApiResponseDtoVoid", voidSchema);
+        };
+    }
 }

--- a/src/main/java/zim/tave/memory/config/swagger/SwaggerErrorCodeExampleCustomizer.java
+++ b/src/main/java/zim/tave/memory/config/swagger/SwaggerErrorCodeExampleCustomizer.java
@@ -65,10 +65,10 @@ public class SwaggerErrorCodeExampleCustomizer implements OperationCustomizer {
                 apiResponse.getContent().addMediaType("application/json", mediaType);
             }
 
-            // Schema 설정 (ApiResponseDto 참조)
+            // Schema 설정 (ApiResponseDto<Void> 참조 - 에러 응답은 data가 null이므로 ApiResponseDtoVoid로 생성됨)
             if (mediaType.getSchema() == null) {
                 io.swagger.v3.oas.models.media.Schema<?> schema = new io.swagger.v3.oas.models.media.Schema<>();
-                schema.set$ref("#/components/schemas/ApiResponseDto");
+                schema.set$ref("#/components/schemas/ApiResponseDtoVoid");
                 mediaType.setSchema(schema);
             }
 
@@ -142,6 +142,8 @@ public class SwaggerErrorCodeExampleCustomizer implements OperationCustomizer {
             case TRIP_NAME_REQUIRED -> ResponseCode.TRIP_NAME_REQUIRED;
             case TRIP_NAME_TOO_LONG -> ResponseCode.TRIP_NAME_TOO_LONG;
             case TRIP_DESCRIPTION_TOO_LONG -> ResponseCode.TRIP_DESCRIPTION_TOO_LONG;
+            case NOT_PAST_TRIP -> ResponseCode.NOT_PAST_TRIP;
+            case CANNOT_ADD_DIARY_TO_PAST_TRIP -> ResponseCode.CANNOT_ADD_DIARY_TO_PAST_TRIP;
             case KAKAO_LOGIN_REQUIRED -> ResponseCode.KAKAO_LOGIN_REQUIRED;
             case INCOMPLETE_USER_INFO -> ResponseCode.INCOMPLETE_USER_INFO;
             case ALREADY_JOINED -> ResponseCode.ALREADY_JOINED;
@@ -151,6 +153,29 @@ public class SwaggerErrorCodeExampleCustomizer implements OperationCustomizer {
             case FILE_TOO_LARGE -> ResponseCode.FILE_TOO_LARGE;
             case FILE_TYPE_NOT_ALLOWED -> ResponseCode.FILE_TYPE_NOT_ALLOWED;
             case FILE_UPLOAD_FAILED -> ResponseCode.FILE_UPLOAD_FAILED;
+            // 보관
+            case TRIP_NOT_STORED -> ResponseCode.TRIP_NOT_STORED;
+            case DIARY_NOT_STORED -> ResponseCode.DIARY_NOT_STORED;
+            // 카카오 로그인
+            case KAKAO_TOKEN_MISSING -> ResponseCode.KAKAO_TOKEN_MISSING;
+            case KAKAO_INVALID_TOKEN -> ResponseCode.KAKAO_INVALID_TOKEN;
+            case KAKAO_UNAUTHORIZED -> ResponseCode.KAKAO_UNAUTHORIZED;
+            case KAKAO_SERVER_ERROR -> ResponseCode.KAKAO_SERVER_ERROR;
+            case KAKAO_RESPONSE_PARSING_ERROR -> ResponseCode.KAKAO_RESPONSE_PARSING_ERROR;
+            case KAKAO_API_UNKNOWN_ERROR -> ResponseCode.KAKAO_API_UNKNOWN_ERROR;
+            // 보드
+            case BOARD_REQUIRED_FIELDS_MISSING -> ResponseCode.BOARD_REQUIRED_FIELDS_MISSING;
+            case BOARD_THEME_NOT_FOUND -> ResponseCode.BOARD_THEME_NOT_FOUND;
+            case BOARD_CREATE_FAILED -> ResponseCode.BOARD_CREATE_FAILED;
+            case BOARD_NOT_FOUND -> ResponseCode.BOARD_NOT_FOUND;
+            case BOARD_UPDATE_FORBIDDEN -> ResponseCode.BOARD_UPDATE_FORBIDDEN;
+            case BOARD_STICKER_NOT_FOUND -> ResponseCode.BOARD_STICKER_NOT_FOUND;
+            case BOARD_UPDATE_INTERNAL_ERROR -> ResponseCode.BOARD_UPDATE_INTERNAL_ERROR;
+            case BOARD_DELETE_FORBIDDEN -> ResponseCode.BOARD_DELETE_FORBIDDEN;
+            case BOARD_STICKER_MAP_NOT_FOUND -> ResponseCode.BOARD_STICKER_MAP_NOT_FOUND;
+            case BOARD_ACCESS_FORBIDDEN -> ResponseCode.BOARD_ACCESS_FORBIDDEN;
+            // 알림
+            case ALARM_NOT_AGREED -> ResponseCode.ALARM_NOT_AGREED;
             default -> ResponseCode.SERVER_ERROR;
         };
     }

--- a/src/main/java/zim/tave/memory/controller/EmotionController.java
+++ b/src/main/java/zim/tave/memory/controller/EmotionController.java
@@ -2,7 +2,6 @@ package zim.tave.memory.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
@@ -14,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import zim.tave.memory.config.swagger.ApiErrorCodeExamples;
 import zim.tave.memory.domain.Emotion;
+import zim.tave.memory.global.common.ApiResponseDto;
+import zim.tave.memory.global.common.ResponseCode;
 import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.service.EmotionService;
 
@@ -35,8 +36,8 @@ public class EmotionController {
             content = @Content)
     })
     @GetMapping("")
-    public ResponseEntity<List<Emotion>> getAllEmotions() {
+    public ResponseEntity<ApiResponseDto<List<Emotion>>> getAllEmotions() {
         List<Emotion> emotions = emotionService.getAllEmotions();
-        return ResponseEntity.ok(emotions);
+        return ResponseEntity.ok(ApiResponseDto.success(ResponseCode.SUCCESS, emotions));
     }
 }

--- a/src/main/java/zim/tave/memory/controller/JoinController.java
+++ b/src/main/java/zim/tave/memory/controller/JoinController.java
@@ -2,7 +2,6 @@ package zim.tave.memory.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -45,17 +44,17 @@ public class JoinController {
             @ApiResponse(responseCode = "400", description = """
                     잘못된 요청입니다. 다음 에러 코드가 발생할 수 있습니다:
                     - KAKAO_LOGIN_REQUIRED: 카카오 로그인이 필요합니다.
-                    """),
+                    """, content = @Content),
             @ApiResponse(responseCode = "401", description = """
                     인증 실패입니다. 다음 에러 코드가 발생할 수 있습니다:
                     - AUTHENTICATION_FAILED
                     - INVALID_TOKEN
                     - UNAUTHORIZED_USER
-                    """),
+                    """, content = @Content),
             @ApiResponse(responseCode = "409", description = """
                     중복 가입 오류입니다:
                     - ALREADY_JOINED: 이미 가입된 사용자입니다.
-                    """)
+                    """, content = @Content)
     })
     @PostMapping("/join")
     public ResponseEntity<ApiResponseDto<UserResponseDto>> join(

--- a/src/main/java/zim/tave/memory/controller/MyPageController.java
+++ b/src/main/java/zim/tave/memory/controller/MyPageController.java
@@ -2,7 +2,6 @@ package zim.tave.memory.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -19,7 +18,6 @@ import zim.tave.memory.dto.response.VisitedCountryListResponseDto;
 import zim.tave.memory.global.common.ApiResponseDto;
 import zim.tave.memory.global.common.ResponseCode;
 import zim.tave.memory.global.common.exception.ErrorCode;
-import zim.tave.memory.security.CustomUserDetails;
 import zim.tave.memory.service.MyPageService;
 import zim.tave.memory.service.VisitedCountryService;
 
@@ -93,7 +91,8 @@ public class MyPageController {
                 - USER_NOT_FOUND: 사용자를 찾을 수 없습니다.
                 - VISITED_COUNTRY_NOT_FOUND: 방문한 국가 정보가 없습니다.
                 """, content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 방문 국가 조회에 실패하였습니다.")
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 방문 국가 조회에 실패하였습니다.",
+                content = @Content)
     })
     @GetMapping("/mypage-visited-countries")
     public ResponseEntity<ApiResponseDto<VisitedCountryListResponseDto>> getVisitedCountries(

--- a/src/main/java/zim/tave/memory/controller/SettingController.java
+++ b/src/main/java/zim/tave/memory/controller/SettingController.java
@@ -84,7 +84,8 @@ public class SettingController {
                 리소스를 찾을 수 없습니다:
                 - USER_NOT_FOUND: 사용자를 찾을 수 없습니다.
                 """, content = @Content),
-            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 회원 정보 수정 실패")
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 회원 정보 수정 실패",
+                content = @Content)
     })
     @PatchMapping("/users/me")
     public ResponseEntity<ApiResponseDto<UserResponseDto>> updateUserInfo(

--- a/src/main/java/zim/tave/memory/controller/StorageController.java
+++ b/src/main/java/zim/tave/memory/controller/StorageController.java
@@ -18,7 +18,6 @@ import zim.tave.memory.dto.response.StoredTripListResponseDto;
 import zim.tave.memory.global.common.ApiResponseDto;
 import zim.tave.memory.global.common.ResponseCode;
 import zim.tave.memory.global.common.exception.ErrorCode;
-import zim.tave.memory.security.CustomUserDetails;
 import zim.tave.memory.service.StorageService;
 
 import java.util.List;

--- a/src/main/java/zim/tave/memory/controller/TripThemeController.java
+++ b/src/main/java/zim/tave/memory/controller/TripThemeController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 import zim.tave.memory.config.swagger.ApiErrorCodeExamples;
 import zim.tave.memory.domain.TripTheme;
 import zim.tave.memory.dto.response.TripThemeResponseDto;
+import zim.tave.memory.global.common.ApiResponseDto;
+import zim.tave.memory.global.common.ResponseCode;
 import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.TripThemeRepository;
 
@@ -37,11 +39,11 @@ public class TripThemeController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
                     content = @Content)
     })
-    public ResponseEntity<List<TripThemeResponseDto>> getAllThemes() {
+    public ResponseEntity<ApiResponseDto<List<TripThemeResponseDto>>> getAllThemes() {
         List<TripTheme> themes = tripThemeRepository.findAllByOrderById();
         List<TripThemeResponseDto> response = themes.stream()
                 .map(TripThemeResponseDto::from)
                 .collect(Collectors.toList());
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponseDto.success(ResponseCode.SUCCESS, response));
     }
 }

--- a/src/main/java/zim/tave/memory/controller/WeatherController.java
+++ b/src/main/java/zim/tave/memory/controller/WeatherController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import zim.tave.memory.config.swagger.ApiErrorCodeExamples;
 import zim.tave.memory.dto.response.WeatherResponseDto;
+import zim.tave.memory.global.common.ApiResponseDto;
+import zim.tave.memory.global.common.ResponseCode;
 import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.service.WeatherService;
 
@@ -34,9 +36,9 @@ public class WeatherController {
             @ApiResponse(responseCode = "500", description = "서버 오류입니다.",
                     content = @Content)
     })
-    public ResponseEntity<List<WeatherResponseDto>> getAllWeathers() {
+    public ResponseEntity<ApiResponseDto<List<WeatherResponseDto>>> getAllWeathers() {
         List<WeatherResponseDto> weathers = weatherService.getAllWeathers();
-        return ResponseEntity.ok(weathers);
+        return ResponseEntity.ok(ApiResponseDto.success(ResponseCode.SUCCESS, weathers));
     }
 
     @GetMapping("/{weatherId}")
@@ -47,9 +49,10 @@ public class WeatherController {
             @ApiResponse(responseCode = "404", description = "날씨를 찾을 수 없습니다.\n- WEATHER_NOT_FOUND: 날씨를 찾을 수 없습니다.",
                     content = @Content)
     })
-    public WeatherResponseDto getWeatherById(
+    public ResponseEntity<ApiResponseDto<WeatherResponseDto>> getWeatherById(
             @Parameter(description = "날씨 ID", required = true, example = "1")
             @PathVariable Long weatherId) {
-        return weatherService.getWeatherById(weatherId);
+        WeatherResponseDto weather = weatherService.getWeatherById(weatherId);
+        return ResponseEntity.ok(ApiResponseDto.success(ResponseCode.SUCCESS, weather));
     }
 }

--- a/src/main/java/zim/tave/memory/global/common/ApiResponseDto.java
+++ b/src/main/java/zim/tave/memory/global/common/ApiResponseDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(name = "ApiResponseDto", description = "공통 응답 형식")
+@Schema(description = "공통 응답 형식")
 public class ApiResponseDto<T> {
 
     @Schema(description = "응답 코드")
@@ -18,6 +18,8 @@ public class ApiResponseDto<T> {
 
     @Schema(description = "응답 메시지")
     private String message;
+    
+    @Schema(description = "데이터")
     private T data;
 
     // 성공 응답


### PR DESCRIPTION
## 🔗 Related Issue
- #73 

## 📝 Description
> 무엇을(What), 왜(Why) 변경했는지 설명합니다.

### 기획 배경 및 비즈니스 문제
- 문제점: 공통 응답 포맷인 ApiResponseDto<T>를 도입했으나, Swagger 문서상에서 모든 API의 data 필드가 특정 DTO(예: UserResponseDto)로 고정되어 표시되는 현상이 발생했습니다.
- 원인: ApiResponseDto에 설정된 @Schema(name = "ApiResponseDto")가 Springdoc의 제네릭 해석을 방해하여 단일 스키마로 병합되었으며, 커스텀 에러 응답 처리기가 고정된 스키마 이름을 참조하고 있었습니다.
- 목표: 제네릭 타입별로 정확한 응답 모델이 노출되도록 개선하고, 에러 응답 포맷(ApiResponseDto<Void>)을 표준화하여 문서의 정확도를 높입니다.

## 🛠 Changes
> 핵심 변경 사항을 요약합니다.
### 1. Swagger 응답 모델 최적화 (Generic Type 지원)

- **`ApiResponseDto` 스키마 설정 수정**: `@Schema(name = "ApiResponseDto")` 선언을 삭제했습니다.
    - **이유**: 고정된 이름을 제거함으로써 Springdoc이 제네릭 타입(`T`)을 분석하여 `ApiResponseDtoUserResponseDto`와 같이 타입별로 고유한 스키마를 생성하도록 개선했습니다.
    - **효과**: 모든 API의 응답 데이터가 특정 DTO로 고정되어 보이던 버그를 해결했습니다.

### 2. 에러 응답 전용 스키마(`ApiResponseDtoVoid`) 도입

- **`OpenApiConfig` 스키마 명시적 등록**: `OpenApiCustomizer`를 통해 `ApiResponseDtoVoid` 스키마를 공통 컴포넌트에 등록했습니다.
    - 에러 응답은 `data` 필드가 항상 `null`이므로 `ApiResponseDto<Void>` 형태를 표준으로 정의했습니다.
- **`SwaggerErrorCodeExampleCustomizer` 수정 (68-73라인)**:
    - 에러 응답 스키마 참조를 `#/components/schemas/ApiResponseDto` → `#/components/schemas/ApiResponseDtoVoid`로 변경하여 성공 응답 모델과의 간섭을 차단했습니다.
    - `CANNOT_ADD_DIARY_TO_PAST_TRIP` 등 누락되었던 `ErrorCode` 매핑 로직을 추가했습니다.

### 3. 컨트롤러 응답 정의 규칙 통일

모든 컨트롤러 API 명세를 아래 표준 규칙에 맞춰 리팩토링했습니다.

| **구분** | **적용 내용** | **동작 원리** |
| --- | --- | --- |
| **공통 응답** | `ResponseEntity<ApiResponseDto<T>>` 적용 | 전사적 응답 포맷 일관성 유지 |
| **성공 응답** | `@ApiResponse` 내 `content` 속성 제거 | Springdoc이 메서드 반환 타입을 읽어 **자동으로 스키마/예시 생성** |
| **에러 응답** | `content = @Content` 속성 유지 | `SwaggerErrorCodeExampleCustomizer`가 커스텀 에러 예시를 주입하도록 보장 |


## ✅ Test Checklist
> 변경 사항이 정상적으로 동작하는지 확인하기 위해 수행한 테스트 목록입니다.
- [x] 각 컨트롤러(Diary, Country 등)의 성공 응답 data 필드에 해당 도메인 DTO 구조가 올바르게 표시되는가?