### PR TITLE
fix: 클라이언트아이디 및 로그 추가

### DIFF
--- a/src/main/java/zim/tave/memory/controller/LoginController.java
+++ b/src/main/java/zim/tave/memory/controller/LoginController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +33,7 @@ import zim.tave.memory.service.LoginService;
 
 import java.util.Arrays;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -85,7 +87,13 @@ public class LoginController {
     @GetMapping("/login/kakao")
     public ResponseEntity<ApiResponseDto<LoginResponseDto>> kakaoLoginWithCode(
             @RequestParam String code,
+            HttpServletRequest request,
             HttpServletResponse response) {
+
+        log.error("[KAKAO CONTROLLER] URI={}, queryString={}, code={}",
+                request.getRequestURI(),
+                request.getQueryString(),
+                code);
 
         // 1. 인가 코드로 카카오 액세스 토큰 획득
         String kakaoAccessToken = kakaoOAuthService.getAccessToken(code);
@@ -137,6 +145,10 @@ public class LoginController {
     public ResponseEntity<ApiResponseDto<TokenRefreshResponse>> refreshToken(
             HttpServletRequest request,
             HttpServletResponse response) {
+
+        log.error("[REFRESH] cookies={}",
+                request.getCookies() == null ? "null" : Arrays.toString(request.getCookies()));
+
 
         // 1. HttpOnly 쿠키에서 Refresh Token 추출
         String refreshToken = getRefreshTokenFromCookie(request);

--- a/src/main/java/zim/tave/memory/global/common/ResponseCode.java
+++ b/src/main/java/zim/tave/memory/global/common/ResponseCode.java
@@ -99,6 +99,7 @@ public enum ResponseCode {
     MALFORMED_TOKEN(401, "올바르지 않은 JWT 형식입니다."),
     INVALID_TOKEN_SIGNATURE(401, "JWT 서명이 유효하지 않습니다."),
     UNSUPPORTED_TOKEN(401, "지원하지 않는 JWT 토큰입니다."),
+    INVALID_REQUEST_PARAMETER(400, "필수 요청 파라미터가 누락되었습니다."),
 
 
     // 카카오로그인 관련 에러

--- a/src/main/java/zim/tave/memory/global/common/exception/ErrorCode.java
+++ b/src/main/java/zim/tave/memory/global/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 JWT 형식입니다."),
     INVALID_TOKEN_SIGNATURE(HttpStatus.UNAUTHORIZED, "JWT 서명이 유효하지 않습니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다."),
+    INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
 
     //설정
     NO_FIELDS_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 필드가 없습니다."),

--- a/src/main/java/zim/tave/memory/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/zim/tave/memory/global/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import zim.tave.memory.global.common.ApiResponseDto;
@@ -75,6 +76,7 @@ public class GlobalExceptionHandler {
             case INVALID_TOKEN_SIGNATURE -> ResponseCode.INVALID_TOKEN_SIGNATURE;
             case UNSUPPORTED_TOKEN -> ResponseCode.UNSUPPORTED_TOKEN;
             case INVALID_REFRESH_TOKEN -> ResponseCode.INVALID_REFRESH_TOKEN;
+            case INVALID_REQUEST_PARAMETER -> ResponseCode.INVALID_REQUEST_PARAMETER;
 
             //보관
             case TRIP_NOT_STORED -> ResponseCode.TRIP_NOT_STORED;
@@ -162,5 +164,22 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponseDto.error(ResponseCode.SERVER_ERROR, safeMessage));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleMissingParam(
+            MissingServletRequestParameterException e,
+            HttpServletRequest request) {
+
+        log.error("[MISSING PARAM] uri={}, missingParam={}",
+                request.getRequestURI(),
+                e.getParameterName());
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST_PARAMETER.getHttpStatus())
+                .body(ApiResponseDto.error(
+                        ResponseCode.INVALID_REQUEST,
+                        "필수 요청 파라미터가 누락되었습니다: " + e.getParameterName()
+                ));
     }
 }

--- a/src/main/java/zim/tave/memory/kakao/KakaoApiClient.java
+++ b/src/main/java/zim/tave/memory/kakao/KakaoApiClient.java
@@ -1,12 +1,15 @@
 package zim.tave.memory.kakao;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import zim.tave.memory.global.common.exception.CustomException;
 import zim.tave.memory.global.common.exception.ErrorCode;
 
 //accessToken으로 카카오 정보 가져옴
+@Slf4j
 @Component
 public class KakaoApiClient {
     private final RestTemplate restTemplate = new RestTemplate();
@@ -31,6 +34,8 @@ public class KakaoApiClient {
                     KakaoInfoResponse.class
             );
 
+            log.info("[KAKAO][ME] status={}, hasBody={}", response.getStatusCode(), response.hasBody());
+
             // HTTP Status 체크
             int status = response.getStatusCodeValue();
 
@@ -54,9 +59,15 @@ public class KakaoApiClient {
                     body.getKakaoAccount().getProfile().getProfileImageUrl()
             );
 
+        } catch (HttpStatusCodeException e) {
+            log.error("[KAKAO][ME] HTTP error. status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new CustomException(ErrorCode.KAKAO_API_UNKNOWN_ERROR);
+
         } catch (CustomException e) {
-            throw e; // 정확한 에러코드 그대로 전달
+            throw e;
+
         } catch (Exception e) {
+            log.error("[KAKAO][ME] unknown error.", e);
             throw new CustomException(ErrorCode.KAKAO_API_UNKNOWN_ERROR);
         }
     }

--- a/src/main/java/zim/tave/memory/security/JwtAuthenticationFilter.java
+++ b/src/main/java/zim/tave/memory/security/JwtAuthenticationFilter.java
@@ -29,6 +29,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain)
             throws ServletException, IOException {
+        log.error("[FILTER] URI={}, query={}",
+                request.getRequestURI(),
+                request.getQueryString());
         log.info("✅ JwtAuthenticationFilter 진입: {}", request.getRequestURI());
 
         String header = request.getHeader("Authorization");

--- a/src/main/java/zim/tave/memory/service/KakaoOAuthService.java
+++ b/src/main/java/zim/tave/memory/service/KakaoOAuthService.java
@@ -1,12 +1,15 @@
 package zim.tave.memory.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import zim.tave.memory.domain.User;
 import zim.tave.memory.dto.response.KakaoTokenResponse;
@@ -17,6 +20,9 @@ import zim.tave.memory.kakao.KakaoApiClient;
 import zim.tave.memory.kakao.KakaoUserInfo;
 import zim.tave.memory.repository.UserRepository;
 
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoOAuthService {
@@ -31,6 +37,12 @@ public class KakaoOAuthService {
 
     // 인가 코드로 카카오 액세스 토큰 요청
     public String getAccessToken(String code) {
+
+        log.error("[KAKAO SERVICE] start. code={}, redirectUri={}, clientIdPrefix={}",
+                code,
+                redirectUri,
+                clientId != null ? clientId.substring(0, 6) : "null");
+
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -50,15 +62,62 @@ public class KakaoOAuthService {
                     KakaoTokenResponse.class
             );
 
+            log.info("[KAKAO][TOKEN] response status={}, hasBody={}",
+                    response.getStatusCode(), response.hasBody());
+
             KakaoTokenResponse body = response.getBody();
             if (body == null || body.getAccessToken() == null) {
                 throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
             }
 
+            if (body.getAccessToken() == null || body.getAccessToken().isBlank()) {
+                log.error("[KAKAO][TOKEN] accessToken missing in body. check parsing/response. status={}",
+                        response.getStatusCode());
+                throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+            }
+
+            log.info("[KAKAO][TOKEN] success. accessTokenLen={}", body.getAccessToken().length());
             return body.getAccessToken();
 
+
+        } catch (HttpStatusCodeException e) {
+            // 여기서가 핵심: 카카오가 준 에러 본문을 남겨야 원인(redirect mismatch / invalid_client 등) 확정 가능
+            String respBody = e.getResponseBodyAsString(StandardCharsets.UTF_8);
+
+            log.error("[KAKAO][TOKEN] HTTP error. status={}, responseBody={}, redirectUri={}, clientIdPrefix={}, code={}",
+                    e.getStatusCode(),
+                    shrink(respBody),
+                    redirectUri,
+                    prefix(clientId),
+                    code
+            );
+
+            throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+
+        } catch (ResourceAccessException e) {
+            // 네트워크/타임아웃
+            log.error("[KAKAO][TOKEN] network error. msg={}, redirectUri={}, code={}",
+                    e.getMessage(), redirectUri, code, e);
+            throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+
+        } catch (CustomException e) {
+            throw e;
+
         } catch (Exception e) {
+            log.error("[KAKAO][TOKEN] unknown error. redirectUri={}, code={}",
+                    redirectUri, code, e);
             throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
         }
+    }
+
+    private String prefix(String s) {
+        if (s == null) return "null";
+        return s.length() <= 6 ? s : s.substring(0, 6) + "...";
+    }
+
+    private String shrink(String s) {
+        if (s == null) return "null";
+        // 로그 폭주 방지
+        return s.length() <= 500 ? s : s.substring(0, 500) + "...(truncated)";
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,4 +17,5 @@ memory:
   base-url: https://voyame-studio.org
 
 kakao:
+  client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: https://voyame-studio.org/api/auth/login/kakao


### PR DESCRIPTION
## 🔗 Related Issue
- #84 

## 📝 Description
> 무엇을(What), 왜(Why) 변경했는지 설명합니다.

### 기획 배경 및 비즈니스 문제
- 프론트엔드 환경에서 카카오 로그인 시 500 에러가 발생하는 문제가 확인되었습니다.
- 서버 단독 테스트(curl, 브라우저 직접 접근)에서는 정상 동작했으나, 프론트 환경에서만 로그인 실패가 발생하여 원인 추적이 필요했습니다.
- 카카오 OAuth 토큰 교환 과정, 쿠키 설정(Refresh Token), 요청 파라미터 전달 여부 등을 정확히 확인하기 위해 서버 로그를 강화했습니다.
- authorization code 전달 여부 및 Refresh Token 쿠키 저장/전달 문제를 추적하기 위한 상세 로그를 추가했습니다.

## 🛠 Changes
> 핵심 변경 사항을 요약합니다.

- 로그 강화
-- LoginController에 카카오 로그인 요청 URI, queryString, code 값 로그 추가
-- KakaoOAuthService에 clientId prefix, redirectUri, code 값 로그 추가
-- 카카오 토큰 요청 실패 시 응답 바디(responseBody) 상세 로그 추가
-- refreshToken() 메서드에 쿠키 존재 여부 및 토큰 검증 로그 추가
- 에러 원인 추적 개선
-- HttpStatusCodeException에서 카카오 에러 응답 JSON을 로그로 남기도록 수정
-- Refresh Token이 브라우저에서 전달되지 않는 경우를 식별할 수 있도록 쿠키 로그 추가
- 디버깅 편의성 개선
-- 카카오 accessToken 길이 및 상태 코드 로그 추가
-- 인가 코드(code) 누락 요청에 대한 명확한 로그 출력

## ✅ Test Checklist
> 변경 사항이 정상적으로 동작하는지 확인하기 위해 수행한 테스트 목록입니다.

- [x] 로컬 로그인 테스트 확인