### PR TITLE
Feat/87 board ai

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,28 +14,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Java 17 세팅
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: gradle
-
-      # 3. Gradle 빌드
-      - name: Build with Gradle
-        run: |
-          chmod +x ./gradlew
-          ./gradlew clean build -x test
-
-      # 4. Docker Hub 로그인
+      # 2. Docker Hub 로그인
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 5. Docker 이미지 빌드 & 푸시
+      # 3. Docker 이미지 빌드 & 푸시 (Dockerfile 안에서 Gradle 빌드)
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -43,7 +29,7 @@ jobs:
           push: true
           tags: choehyungwon/memory-app:latest
 
-      # 6. EC2 SSH 접속 후 배포
+      # 4. EC2 SSH 접속 후 배포
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -51,30 +37,37 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            docker pull choehyungwon/memory-app:latest
+            cd /app
 
-            docker stop memory-app || true
-            docker rm memory-app || true
+            # .env 파일을 GitHub Secrets로 매 배포마다 덮어씀
+            cat > .env << 'EOF'
+            MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}
+            MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}
+            MYSQL_USER=${{ secrets.MYSQL_USER }}
+            MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}
+            SPRING_DATASOURCE_URL=${{ secrets.SPRING_DATASOURCE_URL }}
+            SPRING_DATASOURCE_USERNAME=${{ secrets.MYSQL_USER }}
+            SPRING_DATASOURCE_PASSWORD=${{ secrets.MYSQL_PASSWORD }}
+            AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
+            AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
+            AWS_REGION=${{ secrets.AWS_REGION }}
+            AWS_BUCKET=${{ secrets.AWS_BUCKET }}
+            KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
+            AI_SERVER_URL=${{ secrets.AI_SERVER_URL }}
+            EOF
 
-            docker run -d \
-              --name memory-app \
-              --network memory-net \
-              --restart unless-stopped \
-              -p 8081:8081 \
-              -e SPRING_DATASOURCE_URL="jdbc:mysql://memory-mysql:3306/memory_db?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true" \
-              -e SPRING_DATASOURCE_USERNAME="$MYSQL_USER" \
-              -e SPRING_DATASOURCE_PASSWORD="$MYSQL_PASSWORD" \
-              choehyungwon/memory-app:latest
+            # 최신 이미지 받아서 재시작
+            docker-compose pull
+            docker-compose up -d
 
             # 헬스체크 대기
             echo "⏳ 애플리케이션 시작 대기 중..."
             sleep 30
 
-            # 상태 확인
             if curl -f http://localhost:8081/actuator/health; then
               echo "✅ 배포 성공!"
             else
               echo "❌ 배포 실패 - 로그 확인 필요"
-              docker logs memory-app --tail 50
+              docker-compose logs app --tail 50
               exit 1
             fi

--- a/src/main/java/zim/tave/memory/config/RestTemplateConfig.java
+++ b/src/main/java/zim/tave/memory/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package zim.tave.memory.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/zim/tave/memory/controller/StickerController.java
+++ b/src/main/java/zim/tave/memory/controller/StickerController.java
@@ -1,0 +1,14 @@
+package zim.tave.memory.controller;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me/stickers")
+@SecurityRequirement(name = "bearerAuth")
+public class StickerController {
+
+}

--- a/src/main/java/zim/tave/memory/controller/StickerController.java
+++ b/src/main/java/zim/tave/memory/controller/StickerController.java
@@ -1,9 +1,23 @@
 package zim.tave.memory.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import zim.tave.memory.config.swagger.ApiErrorCodeExamples;
+import zim.tave.memory.dto.response.StickerCreateResponseDto;
+import zim.tave.memory.dto.response.StickerListResponseDto;
+import zim.tave.memory.global.common.ApiResponseDto;
+import zim.tave.memory.global.common.ResponseCode;
+import zim.tave.memory.global.common.exception.ErrorCode;
+import zim.tave.memory.service.StickerService;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,4 +25,53 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "bearerAuth")
 public class StickerController {
 
+    private final StickerService stickerService;
+
+    @Operation(
+            summary = "AI 스티커 생성",
+            description = "이미지를 업로드하면 AI가 수채화 스티커 스타일로 변환하여 저장합니다."
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.FILE_EMPTY,
+            ErrorCode.FILE_TOO_LARGE,
+            ErrorCode.FILE_TYPE_NOT_ALLOWED,
+            ErrorCode.FILE_UPLOAD_FAILED,
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_TOKEN,
+            ErrorCode.UNAUTHORIZED_USER,
+            ErrorCode.USER_NOT_FOUND
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "스티커 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파일"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "AI 변환 또는 업로드 실패")
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponseDto<StickerCreateResponseDto>> createSticker(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @RequestPart("image") MultipartFile image
+    ) {
+        StickerCreateResponseDto response = stickerService.createSticker(userId, image);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.success(ResponseCode.STICKER_CREATE_SUCCESS, response));
+    }
+
+    @Operation(
+            summary = "내 스티커 목록 조회",
+            description = "로그인한 사용자가 생성한 전체 스티커를 조회합니다."
+    )
+    @ApiErrorCodeExamples({
+            ErrorCode.AUTHENTICATION_FAILED,
+            ErrorCode.INVALID_TOKEN,
+            ErrorCode.UNAUTHORIZED_USER
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<StickerListResponseDto>> getMyStickers(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        StickerListResponseDto response = stickerService.getMyStickers(userId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponseDto.success(ResponseCode.SUCCESS, response));
+    }
 }

--- a/src/main/java/zim/tave/memory/domain/User.java
+++ b/src/main/java/zim/tave/memory/domain/User.java
@@ -62,5 +62,8 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Diary> diaries = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserSticker> userStickers = new ArrayList<>();
 }
 

--- a/src/main/java/zim/tave/memory/domain/UserSticker.java
+++ b/src/main/java/zim/tave/memory/domain/UserSticker.java
@@ -1,0 +1,38 @@
+package zim.tave.memory.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "UserSticker")
+public class UserSticker {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "userStickerId")
+    private Long userStickerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stickerId", nullable = false)
+    private Sticker sticker;
+
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/zim/tave/memory/dto/response/StickerCreateResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/StickerCreateResponseDto.java
@@ -1,0 +1,31 @@
+package zim.tave.memory.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import zim.tave.memory.domain.Sticker;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "AI 스티커 생성 응답 DTO")
+public class StickerCreateResponseDto {
+
+    @Schema(description = "스티커 ID", example = "42")
+    private Long stickerId;
+
+    @Schema(description = "스티커 이름", example = "my_photo")
+    private String name;
+
+    @Schema(description = "S3 이미지 URL", example = "https://bucket.s3.ap-northeast-2.amazonaws.com/stickers/user-1/abc.png")
+    private String imageUrl;
+
+    public static StickerCreateResponseDto from(Sticker sticker) {
+        return new StickerCreateResponseDto(
+                sticker.getStickerId(),
+                sticker.getName(),
+                sticker.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/zim/tave/memory/dto/response/StickerCreateResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/StickerCreateResponseDto.java
@@ -2,6 +2,7 @@ package zim.tave.memory.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zim.tave.memory.domain.Sticker;
@@ -9,6 +10,7 @@ import zim.tave.memory.domain.Sticker;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Schema(description = "AI 스티커 생성 응답 DTO")
 public class StickerCreateResponseDto {
 

--- a/src/main/java/zim/tave/memory/dto/response/StickerListResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/StickerListResponseDto.java
@@ -1,0 +1,36 @@
+package zim.tave.memory.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import zim.tave.memory.domain.Sticker;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "스티커 목록 응답 DTO")
+public class StickerListResponseDto {
+
+    @Schema(description = "스티커 목록")
+    private List<StickerItemDto> stickers;
+
+    public static StickerListResponseDto from(List<Sticker> stickers) {
+        List<StickerItemDto> items = stickers.stream()
+                .map(StickerItemDto::from)
+                .toList();
+        return new StickerListResponseDto(items);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class StickerItemDto {
+        private Long stickerId;
+        private String name;
+        private String imageUrl;
+
+        public static StickerItemDto from(Sticker s) {
+            return new StickerItemDto(s.getStickerId(), s.getName(), s.getImageUrl());
+        }
+    }
+}

--- a/src/main/java/zim/tave/memory/dto/response/StickerListResponseDto.java
+++ b/src/main/java/zim/tave/memory/dto/response/StickerListResponseDto.java
@@ -2,6 +2,7 @@ package zim.tave.memory.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import zim.tave.memory.domain.Sticker;
 
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@Builder
 @Schema(description = "스티커 목록 응답 DTO")
 public class StickerListResponseDto {
 

--- a/src/main/java/zim/tave/memory/global/common/ResponseCode.java
+++ b/src/main/java/zim/tave/memory/global/common/ResponseCode.java
@@ -35,6 +35,8 @@ public enum ResponseCode {
     BOARD_UPDATE_SUCCESS(200, "보드 수정이 완료되었습니다."),
     BOARD_DELETE_SUCCESS(200, "보드가 성공적으로 삭제되었습니다."),
     BOARD_FETCH_SUCCESS(200, "보드 정보가 성공적으로 조회되었습니다."),
+    //스티커
+    STICKER_CREATE_SUCCESS(200, "스티커 생성 성공"),
     //알림
     NO_ALARM_TO_SEND(200, "전송할 알림이 없습니다."),
 

--- a/src/main/java/zim/tave/memory/kakao/KakaoApiClient.java
+++ b/src/main/java/zim/tave/memory/kakao/KakaoApiClient.java
@@ -1,5 +1,6 @@
 package zim.tave.memory.kakao;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -11,8 +12,9 @@ import zim.tave.memory.global.common.exception.ErrorCode;
 //accessToken으로 카카오 정보 가져옴
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class KakaoApiClient {
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     public KakaoUserInfo getKakaoUserInfo(String accessToken){
 

--- a/src/main/java/zim/tave/memory/repository/UserStickerRepository.java
+++ b/src/main/java/zim/tave/memory/repository/UserStickerRepository.java
@@ -1,4 +1,11 @@
 package zim.tave.memory.repository;
 
-public class UserStickerRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import zim.tave.memory.domain.UserSticker;
+
+import java.util.List;
+
+public interface UserStickerRepository extends JpaRepository<UserSticker, Long> {
+
+    List<UserSticker> findByUserId(Long userId);
 }

--- a/src/main/java/zim/tave/memory/repository/UserStickerRepository.java
+++ b/src/main/java/zim/tave/memory/repository/UserStickerRepository.java
@@ -1,0 +1,4 @@
+package zim.tave.memory.repository;
+
+public class UserStickerRepository {
+}

--- a/src/main/java/zim/tave/memory/service/StickerService.java
+++ b/src/main/java/zim/tave/memory/service/StickerService.java
@@ -2,6 +2,7 @@ package zim.tave.memory.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -17,6 +18,16 @@ public class StickerService {
     private final UserStickerRepository userStickerRepository;
     private final S3Client s3Client;
     private final RestTemplate restTemplate;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.base-url}")
+    private String s3BaseUrl;
+
 
 
 }

--- a/src/main/java/zim/tave/memory/service/StickerService.java
+++ b/src/main/java/zim/tave/memory/service/StickerService.java
@@ -65,7 +65,8 @@ public class StickerService {
         MultipartFile transformedFile = new ByteArrayMultipartFile(
                 transformedBytes,
                 "sticker.png",
-                "image/png"
+                "image/png",
+                "sticker.png"
         );
 
         // 5. S3 업로드 (S3Uploader 사용)
@@ -106,21 +107,25 @@ public class StickerService {
         private final byte[] data;
         private final String filename;
         private final String contentType;
+        private final String originalFilename;
 
-        public ByteArrayMultipartFile(byte[] data, String filename, String contentType) {
+        public ByteArrayMultipartFile(byte[] data, String filename, String contentType, String originalFilename) {
             this.data = data;
             this.filename = filename;
             this.contentType = contentType;
+            this.originalFilename = originalFilename;
         }
 
+        // 파라미터 이름
         @Override
         public String getName() {
             return filename;
         }
 
+        // 실제 파일이름
         @Override
         public String getOriginalFilename() {
-            return filename;
+            return originalFilename;
         }
 
         @Override

--- a/src/main/java/zim/tave/memory/service/StickerService.java
+++ b/src/main/java/zim/tave/memory/service/StickerService.java
@@ -26,8 +26,12 @@ import zim.tave.memory.repository.StickerRepository;
 import zim.tave.memory.repository.UserRepository;
 import zim.tave.memory.repository.UserStickerRepository;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -36,56 +40,118 @@ public class StickerService {
 
     private final StickerRepository stickerRepository;
     private final UserStickerRepository userStickerRepository;
-    private final S3Client s3Client;
     private final RestTemplate restTemplate;
     private final FileUploadProperties fileUploadProperties;
     private final UserRepository userRepository;
+    private final S3Uploader s3Uploader;
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    @Value("${cloud.aws.s3.base-url}")
-    private String s3BaseUrl;
-
-    private static final List<String> ALLOWED_TYPES =
-            List.of("image/jpeg", "image/png", "image/webp");
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024L; // 10MB
-
     @Transactional
     public StickerCreateResponseDto createSticker(Long userId, MultipartFile file) {
 
-        // 1. 파일 유효성 검사
+        // 1. 파일 유효성 검사 (yml 기반)
         validateFile(file);
 
-        // 2. Python AI 서버로 이미지 전송 → 변환된 PNG 바이트 수신
+        // 2. 사용자 조회 (userId → User 엔티티)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 3. Python AI 서버 호출 → 변환된 PNG 바이트 수신
         byte[] transformedBytes = callAiServer(file);
 
-        // 3. S3 업로드
-        String s3Key = "stickers/user-" + userId + "/" + UUID.randomUUID() + ".png";
-        uploadToS3(s3Key, transformedBytes);
-        String imageUrl = s3BaseUrl + "/" + s3Key;
+        // 4. 변환된 파일을 MultipartFile처럼 감싸기 (S3Uploader 사용 위해)
+        MultipartFile transformedFile = new ByteArrayMultipartFile(
+                transformedBytes,
+                "sticker.png",
+                "image/png"
+        );
 
-        // 4. Sticker 공통 엔티티 저장 (name은 원본 파일명 기반)
+        // 5. S3 업로드 (S3Uploader 사용)
+        String imageUrl;
+        try {
+            imageUrl = s3Uploader.upload(
+                    transformedFile,
+                    "stickers/user-" + userId
+            );
+        } catch (IOException e) {
+            log.error("S3 업로드 실패", e);
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        // 6. Sticker 저장
         String stickerName = extractBaseName(file.getOriginalFilename());
+
         Sticker sticker = Sticker.builder()
                 .name(stickerName)
                 .imageUrl(imageUrl)
                 .build();
+
         Sticker savedSticker = stickerRepository.save(sticker);
 
-        // 5. UserSticker 연결 저장 (유저-스티커 소유 관계)
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        // 7. UserSticker 저장 (userId → user)
         UserSticker userSticker = UserSticker.builder()
                 .user(user)
                 .sticker(savedSticker)
                 .build();
+
         userStickerRepository.save(userSticker);
 
         return StickerCreateResponseDto.from(savedSticker);
+    }
+
+    public class ByteArrayMultipartFile implements MultipartFile {
+
+        private final byte[] data;
+        private final String filename;
+        private final String contentType;
+
+        public ByteArrayMultipartFile(byte[] data, String filename, String contentType) {
+            this.data = data;
+            this.filename = filename;
+            this.contentType = contentType;
+        }
+
+        @Override
+        public String getName() {
+            return filename;
+        }
+
+        @Override
+        public String getOriginalFilename() {
+            return filename;
+        }
+
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return data.length == 0;
+        }
+
+        @Override
+        public long getSize() {
+            return data.length;
+        }
+
+        @Override
+        public byte[] getBytes() {
+            return data;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        @Override
+        public void transferTo(File dest) throws IOException {
+            Files.write(dest.toPath(), data);
+        }
     }
 
     public StickerListResponseDto getMyStickers(Long userId) {
@@ -160,20 +226,6 @@ public class StickerService {
             throw e;
         } catch (Exception e) {
             log.error("AI 서버 호출 실패: {}", e.getMessage());
-            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
-        }
-    }
-
-    private void uploadToS3(String key, byte[] data) {
-        try {
-            PutObjectRequest request = PutObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(key)
-                    .contentType("image/png")
-                    .build();
-            s3Client.putObject(request, RequestBody.fromBytes(data));
-        } catch (Exception e) {
-            log.error("S3 업로드 실패: {}", e.getMessage());
             throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
         }
     }

--- a/src/main/java/zim/tave/memory/service/StickerService.java
+++ b/src/main/java/zim/tave/memory/service/StickerService.java
@@ -3,10 +3,20 @@ package zim.tave.memory.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import software.amazon.awssdk.services.s3.S3Client;
+import zim.tave.memory.repository.StickerRepository;
+import zim.tave.memory.repository.UserStickerRepository;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StickerService {
+
+    private final StickerRepository stickerRepository;
+    private final UserStickerRepository userStickerRepository;
+    private final S3Client s3Client;
+    private final RestTemplate restTemplate;
+
 
 }

--- a/src/main/java/zim/tave/memory/service/StickerService.java
+++ b/src/main/java/zim/tave/memory/service/StickerService.java
@@ -1,0 +1,12 @@
+package zim.tave.memory.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StickerService {
+
+}

--- a/src/main/java/zim/tave/memory/service/StickerService.java
+++ b/src/main/java/zim/tave/memory/service/StickerService.java
@@ -3,11 +3,31 @@ package zim.tave.memory.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import zim.tave.memory.config.FileUploadProperties;
+import zim.tave.memory.domain.Sticker;
+import zim.tave.memory.domain.User;
+import zim.tave.memory.domain.UserSticker;
+import zim.tave.memory.dto.response.StickerCreateResponseDto;
+import zim.tave.memory.dto.response.StickerListResponseDto;
+import zim.tave.memory.global.common.exception.CustomException;
+import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.StickerRepository;
+import zim.tave.memory.repository.UserRepository;
 import zim.tave.memory.repository.UserStickerRepository;
+
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -18,6 +38,8 @@ public class StickerService {
     private final UserStickerRepository userStickerRepository;
     private final S3Client s3Client;
     private final RestTemplate restTemplate;
+    private final FileUploadProperties fileUploadProperties;
+    private final UserRepository userRepository;
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
@@ -28,6 +50,138 @@ public class StickerService {
     @Value("${cloud.aws.s3.base-url}")
     private String s3BaseUrl;
 
+    private static final List<String> ALLOWED_TYPES =
+            List.of("image/jpeg", "image/png", "image/webp");
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024L; // 10MB
 
+    @Transactional
+    public StickerCreateResponseDto createSticker(Long userId, MultipartFile file) {
+
+        // 1. 파일 유효성 검사
+        validateFile(file);
+
+        // 2. Python AI 서버로 이미지 전송 → 변환된 PNG 바이트 수신
+        byte[] transformedBytes = callAiServer(file);
+
+        // 3. S3 업로드
+        String s3Key = "stickers/user-" + userId + "/" + UUID.randomUUID() + ".png";
+        uploadToS3(s3Key, transformedBytes);
+        String imageUrl = s3BaseUrl + "/" + s3Key;
+
+        // 4. Sticker 공통 엔티티 저장 (name은 원본 파일명 기반)
+        String stickerName = extractBaseName(file.getOriginalFilename());
+        Sticker sticker = Sticker.builder()
+                .name(stickerName)
+                .imageUrl(imageUrl)
+                .build();
+        Sticker savedSticker = stickerRepository.save(sticker);
+
+        // 5. UserSticker 연결 저장 (유저-스티커 소유 관계)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        UserSticker userSticker = UserSticker.builder()
+                .user(user)
+                .sticker(savedSticker)
+                .build();
+        userStickerRepository.save(userSticker);
+
+        return StickerCreateResponseDto.from(savedSticker);
+    }
+
+    public StickerListResponseDto getMyStickers(Long userId) {
+        List<UserSticker> userStickers = userStickerRepository.findByUserId(userId);
+        List<Sticker> stickers = userStickers.stream()
+                .map(UserSticker::getSticker)
+                .toList();
+        return StickerListResponseDto.from(stickers);
+    }
+
+    // ── private helpers ──────────────────────────────────────────────
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorCode.FILE_EMPTY);
+        }
+
+        if (file.getSize() > fileUploadProperties.getMaxFileSize()) {
+            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null ||
+                !fileUploadProperties.getAllowedImageTypes().contains(contentType)) {
+            throw new CustomException(ErrorCode.FILE_TYPE_NOT_ALLOWED);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = extractExtension(originalFilename);
+
+        if (!fileUploadProperties.getAllowedImageExtensions().contains(extension)) {
+            throw new CustomException(ErrorCode.FILE_TYPE_NOT_ALLOWED);
+        }
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || !filename.contains(".")) return "";
+        return filename.substring(filename.lastIndexOf(".")).toLowerCase();
+    }
+
+    private byte[] callAiServer(MultipartFile file) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            ByteArrayResource resource = new ByteArrayResource(file.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return file.getOriginalFilename();
+                }
+            };
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", resource);
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity =
+                    new HttpEntity<>(body, headers);
+
+            ResponseEntity<byte[]> response = restTemplate.exchange(
+                    aiServerUrl + "/transform",
+                    HttpMethod.POST,
+                    requestEntity,
+                    byte[].class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+            }
+            return response.getBody();
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("AI 서버 호출 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private void uploadToS3(String key, byte[] data) {
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType("image/png")
+                    .build();
+            s3Client.putObject(request, RequestBody.fromBytes(data));
+        } catch (Exception e) {
+            log.error("S3 업로드 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private String extractBaseName(String originalFilename) {
+        if (originalFilename == null) return "sticker";
+        int dot = originalFilename.lastIndexOf('.');
+        return dot > 0 ? originalFilename.substring(0, dot) : originalFilename;
+    }
 
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,3 +19,18 @@ memory:
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   redirect-uri: https://voyame-studio.org/api/auth/login/kakao
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${AWS_BUCKET}
+      base-url: https://${AWS_BUCKET}.s3.${AWS_REGION}.amazonaws.com
+
+ai:
+  server:
+    url: ${AI_SERVER_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ server:
   #max-http-request-size: 500MB     # 기존 server.tomcat.max-http-post-size 대체
 
 memory:
-  base-url: https://me-mory01.mooo.com
+  base-url: https://voyame-studio.org
   file-upload:
     max-file-size: 524288000
     allowed-image-types:

--- a/src/main/resources/db/migration/V5__init_create_usersticker.sql
+++ b/src/main/resources/db/migration/V5__init_create_usersticker.sql
@@ -1,0 +1,14 @@
+-- V4__create_user_sticker.sql
+
+-- UserSticker 테이블 (FK: User, Sticker)
+CREATE TABLE IF NOT EXISTS UserSticker (
+    userStickerId BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    userId BIGINT NOT NULL,
+    stickerId BIGINT NOT NULL,
+    createdAt DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP()),
+
+    CONSTRAINT fk_user_sticker_user
+    FOREIGN KEY (userId) REFERENCES User (userId) ON DELETE CASCADE,
+    CONSTRAINT fk_user_sticker_sticker
+    FOREIGN KEY (stickerId) REFERENCES Sticker (stickerId) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/zim/tave/memory/controller/StickerControllerTest.java
+++ b/src/test/java/zim/tave/memory/controller/StickerControllerTest.java
@@ -8,24 +8,31 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import zim.tave.memory.dto.response.StickerCreateResponseDto;
 import zim.tave.memory.dto.response.StickerListResponseDto;
 import zim.tave.memory.global.common.ResponseCode;
+import zim.tave.memory.global.common.exception.CustomException;
+import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.global.common.exception.GlobalExceptionHandler;
 import zim.tave.memory.security.CustomUserDetails;
 import zim.tave.memory.service.StickerService;
 
 import java.util.Collections;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,6 +65,58 @@ public class StickerControllerTest {
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
         SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+    }
+
+    @Test
+    void 스티커_생성_성공() throws Exception {
+        // given
+        Long userId = 1L;
+        setSecurityContext(userId);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "dummy".getBytes()
+        );
+
+        StickerCreateResponseDto responseDto =
+                StickerCreateResponseDto.builder()
+                        .imageUrl("url")
+                        .name("test")
+                        .build();
+
+        given(stickerService.createSticker(eq(userId), any()))
+                .willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(multipart("/api/users/me/stickers")
+                        .file(file))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code")
+                        .value(ResponseCode.STICKER_CREATE_SUCCESS.getCode()));
+
+        verify(stickerService).createSticker(eq(userId), any());
+    }
+
+    @Test
+    void 스티커_생성_실패_파일문제() throws Exception {
+        Long userId = 1L;
+        setSecurityContext(userId);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                new byte[]{}
+        );
+
+        given(stickerService.createSticker(eq(userId), any()))
+                .willThrow(new CustomException(ErrorCode.FILE_EMPTY));
+
+        mockMvc.perform(multipart("/api/users/me/stickers")
+                        .file(file))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/zim/tave/memory/controller/StickerControllerTest.java
+++ b/src/test/java/zim/tave/memory/controller/StickerControllerTest.java
@@ -1,0 +1,82 @@
+package zim.tave.memory.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import zim.tave.memory.dto.response.StickerListResponseDto;
+import zim.tave.memory.global.common.ResponseCode;
+import zim.tave.memory.global.common.exception.GlobalExceptionHandler;
+import zim.tave.memory.security.CustomUserDetails;
+import zim.tave.memory.service.StickerService;
+
+import java.util.Collections;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+public class StickerControllerTest {
+
+    @Mock
+    private StickerService stickerService;
+
+    @InjectMocks
+    private StickerController stickerController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(stickerController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        reset(stickerService);
+    }
+
+    private void setSecurityContext(Long userId) {
+        CustomUserDetails principal = new CustomUserDetails(userId, "test@test.com");
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+    }
+
+    @Test
+    void 내_스티커_목록_조회_성공() throws Exception {
+        // given
+        Long userId = 1L;
+        setSecurityContext(userId);
+
+        StickerListResponseDto responseDto = StickerListResponseDto.builder()
+                .stickers(Collections.emptyList())
+                .build();
+
+        given(stickerService.getMyStickers(userId)).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/users/me/stickers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(ResponseCode.SUCCESS.getCode()));
+
+        verify(stickerService).getMyStickers(userId);
+    }
+}

--- a/src/test/java/zim/tave/memory/service/StickerServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/StickerServiceTest.java
@@ -1,0 +1,51 @@
+package zim.tave.memory.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zim.tave.memory.domain.Sticker;
+import zim.tave.memory.domain.UserSticker;
+import zim.tave.memory.dto.response.StickerListResponseDto;
+import zim.tave.memory.repository.UserStickerRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StickerServiceTest {
+
+    @Mock
+    private UserStickerRepository userStickerRepository;
+
+    @InjectMocks
+    private StickerService stickerService;
+
+    @Test
+    void 내_스티커_목록_조회_성공() {
+        // given
+        Long userId = 1L;
+
+        Sticker sticker = Sticker.builder()
+                .name("test")
+                .imageUrl("url")
+                .build();
+
+        UserSticker userSticker = UserSticker.builder()
+                .sticker(sticker)
+                .build();
+
+        when(userStickerRepository.findByUserId(userId))
+                .thenReturn(List.of(userSticker));
+
+        // when
+        StickerListResponseDto result = stickerService.getMyStickers(userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getStickers()).hasSize(1);
+    }
+}

--- a/src/test/java/zim/tave/memory/service/StickerServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/StickerServiceTest.java
@@ -19,7 +19,9 @@ import zim.tave.memory.repository.StickerRepository;
 import zim.tave.memory.repository.UserRepository;
 import zim.tave.memory.repository.UserStickerRepository;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 
@@ -163,5 +165,105 @@ class StickerServiceTest {
 
         assertThatThrownBy(() -> stickerService.createSticker(userId, file))
                 .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void ByteArrayMultipartFile_전체_커버() throws Exception {
+        byte[] data = "test-data".getBytes();
+
+        StickerService.ByteArrayMultipartFile file =
+                stickerService.new ByteArrayMultipartFile(
+                        data,
+                        "paramName",
+                        "image/png",
+                        "original.png"
+                );
+
+        // 모든 메서드 호출 (coverage 핵심🔥)
+        assertThat(file.getName()).isEqualTo("paramName");
+        assertThat(file.getOriginalFilename()).isEqualTo("original.png");
+        assertThat(file.getContentType()).isEqualTo("image/png");
+        assertThat(file.isEmpty()).isFalse();
+        assertThat(file.getSize()).isEqualTo(data.length);
+        assertThat(file.getBytes()).isEqualTo(data);
+
+        InputStream is = file.getInputStream();
+        assertThat(is).isNotNull();
+
+        File tempFile = File.createTempFile("test", ".png");
+        file.transferTo(tempFile);
+
+        assertThat(tempFile.exists()).isTrue();
+    }
+
+    @Test
+    void 파일_타입_오류() {
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.txt", "text/plain", "data".getBytes()
+        );
+
+        assertThatThrownBy(() -> stickerService.createSticker(1L, file))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void 파일_사이즈_초과() {
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "data".getBytes()
+        );
+
+        when(fileUploadProperties.getMaxFileSize()).thenReturn(1L);
+
+        assertThatThrownBy(() -> stickerService.createSticker(1L, file))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void AI_서버_실패() {
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "data".getBytes()
+        );
+
+        User user = new User();
+        user.setId(1L);
+
+        when(fileUploadProperties.getMaxFileSize()).thenReturn(10_000L);
+        when(fileUploadProperties.getAllowedImageTypes()).thenReturn(List.of("image/jpeg"));
+        when(fileUploadProperties.getAllowedImageExtensions()).thenReturn(List.of(".jpg"));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        when(restTemplate.exchange(anyString(), any(), any(), eq(byte[].class)))
+                .thenThrow(new RuntimeException());
+
+        assertThatThrownBy(() -> stickerService.createSticker(1L, file))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void 파일이름_null이면_sticker() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "image", null, "image/jpeg", "data".getBytes()
+        );
+
+        User user = new User();
+        user.setId(1L);
+
+        when(fileUploadProperties.getMaxFileSize()).thenReturn(10_000L);
+        when(fileUploadProperties.getAllowedImageTypes()).thenReturn(List.of("image/jpeg"));
+        when(fileUploadProperties.getAllowedImageExtensions()).thenReturn(List.of(""));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        when(restTemplate.exchange(anyString(), any(), any(), eq(byte[].class)))
+                .thenReturn(ResponseEntity.ok("converted".getBytes()));
+
+        when(s3Uploader.upload(any(), any())).thenReturn("url");
+
+        when(stickerRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        StickerCreateResponseDto result = stickerService.createSticker(1L, file);
+
+        assertThat(result).isNotNull();
     }
 }

--- a/src/test/java/zim/tave/memory/service/StickerServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/StickerServiceTest.java
@@ -5,14 +5,27 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.client.RestTemplate;
+import zim.tave.memory.config.FileUploadProperties;
 import zim.tave.memory.domain.Sticker;
+import zim.tave.memory.domain.User;
 import zim.tave.memory.domain.UserSticker;
+import zim.tave.memory.dto.response.StickerCreateResponseDto;
 import zim.tave.memory.dto.response.StickerListResponseDto;
+import zim.tave.memory.global.common.exception.CustomException;
+import zim.tave.memory.repository.StickerRepository;
+import zim.tave.memory.repository.UserRepository;
 import zim.tave.memory.repository.UserStickerRepository;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,9 +33,54 @@ class StickerServiceTest {
 
     @Mock
     private UserStickerRepository userStickerRepository;
+    @Mock
+    StickerRepository stickerRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private FileUploadProperties fileUploadProperties;
+    @Mock
+    private S3Uploader s3Uploader;
 
     @InjectMocks
     private StickerService stickerService;
+
+    @Test
+    void 스티커_생성_성공() throws Exception {
+        // given
+        Long userId = 1L;
+
+        MockMultipartFile file = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "dummy".getBytes()
+        );
+
+        User user = new User();
+        user.setId(userId);
+
+        when(fileUploadProperties.getMaxFileSize()).thenReturn(10_000L);
+        when(fileUploadProperties.getAllowedImageTypes()).thenReturn(List.of("image/jpeg"));
+        when(fileUploadProperties.getAllowedImageExtensions()).thenReturn(List.of(".jpg"));
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        when(restTemplate.exchange(anyString(), any(), any(), eq(byte[].class)))
+                .thenReturn(ResponseEntity.ok("converted".getBytes()));
+
+        when(s3Uploader.upload(any(), any())).thenReturn("s3-url");
+
+        when(stickerRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        StickerCreateResponseDto result = stickerService.createSticker(userId, file);
+
+        // then
+        assertThat(result).isNotNull();
+    }
 
     @Test
     void 내_스티커_목록_조회_성공() {
@@ -47,5 +105,63 @@ class StickerServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getStickers()).hasSize(1);
+    }
+
+    @Test
+    void 파일이_null이면_예외() {
+        assertThatThrownBy(() -> stickerService.createSticker(1L, null))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void 파일_empty면_예외() {
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", new byte[]{}
+        );
+
+        assertThatThrownBy(() -> stickerService.createSticker(1L, file))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void 유저없으면_예외() {
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "data".getBytes()
+        );
+
+        when(fileUploadProperties.getMaxFileSize()).thenReturn(10_000L);
+        when(fileUploadProperties.getAllowedImageTypes()).thenReturn(List.of("image/jpeg"));
+        when(fileUploadProperties.getAllowedImageExtensions()).thenReturn(List.of(".jpg"));
+
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> stickerService.createSticker(1L, file))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void S3_업로드_실패() throws Exception {
+        Long userId = 1L;
+
+        MockMultipartFile file = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "data".getBytes()
+        );
+
+        User user = new User();
+        user.setId(userId);
+
+        when(fileUploadProperties.getMaxFileSize()).thenReturn(10_000L);
+        when(fileUploadProperties.getAllowedImageTypes()).thenReturn(List.of("image/jpeg"));
+        when(fileUploadProperties.getAllowedImageExtensions()).thenReturn(List.of(".jpg"));
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        when(restTemplate.exchange(anyString(), any(), any(), eq(byte[].class)))
+                .thenReturn(ResponseEntity.ok("converted".getBytes()));
+
+        when(s3Uploader.upload(any(), any())).thenThrow(new IOException());
+
+        assertThatThrownBy(() -> stickerService.createSticker(userId, file))
+                .isInstanceOf(CustomException.class);
     }
 }


### PR DESCRIPTION
## 🔗 Related Issue
- #87 

## 📝 Description
> 무엇을(What), 왜(Why) 변경했는지 설명합니다.
- 스티커 생성 기능을 신규로 추가하고, AI 기반 이미지 변환 및 S3 업로드까지 포함된 전체 플로우를 구현했습니다.
- 사용자가 이미지를 업로드하면 Python 서버를 통해 스티커 형태로 변환한 후 저장되며, 사용자와 스티커 간 매핑까지 관리됩니다.
- 배포 구조를 개선하여 Docker 기반 단일 빌드 및 .env 기반 환경변수 관리로 통일했습니다.

## 🛠 Changes
> 핵심 변경 사항을 요약합니다.
### 1. 스티커 기능 신규 추가
- **스티커 생성 API**
    - `POST /api/users/me/stickers` (multipart 이미지 업로드)
- **스티커 목록 조회 API**
    - `GET /api/users/me/stickers`
    - 로그인 사용자 기준으로 본인의 스티커 목록 조회
 ---
### 2. 신규/수정 파일
- **신규 생성**
    - `StickerController`
    - `StickerService`
    - `UserSticker` 엔티티
    - `UserStickerRepository`
    - `StickerCreateResponseDto`
    - `StickerListResponseDto`
    - `V5__init_create_usersticker.sql`
- **수정**
    - `RestTemplateConfig` 추가 (외부 API 호출용)
    - `KakaoApiClient` 수정 (RestTemplate 구조 통일)
---
### 3. 외부 연동 (AI 이미지 변환)
- `RestTemplate`을 사용하여 Python 서버(`/transform`)와 통신
- multipart 요청으로 이미지 전달
- 변환된 PNG byte 응답 처리 후 S3 업로드
---
### 4. 배포 구조 개선</h3>

항목 | 기존 | 변경
-- | -- | --
Gradle 빌드 | GitHub Actions + Dockerfile 이중 빌드 | Dockerfile 내부 빌드로 통합
배포 방식 | docker run | docker-compose up -d
환경변수 | 일부만 -e | .env 파일로 전체 관리
Secrets 반영 | 서버 수동 수정 | 배포 시 .env 자동 갱신

---

## ✅ Test Checklist
> 변경 사항이 정상적으로 동작하는지 확인하기 위해 수행한 테스트 목록입니다.

- [x] AI 이미지 생성 정상 동작 확인
- [x] S3 이미지 등록 정상 동작 확인