### PR TITLE
Fix/94 trip country timeline

### DIFF
--- a/src/main/java/zim/tave/memory/domain/Trip.java
+++ b/src/main/java/zim/tave/memory/domain/Trip.java
@@ -58,6 +58,9 @@ public class Trip {
     @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Diary> diaries = new ArrayList<>();
 
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TripCountry> tripCountries = new ArrayList<>();
+
     @PrePersist
     protected void onCreate() {
         if (this.startDate == null) {
@@ -73,6 +76,11 @@ public class Trip {
         diaries.add(diary);
         diary.setTrip(this);
         this.endDate = diary.getCreatedAt().toLocalDate();
+    }
+
+    public void addTripCountry(TripCountry tripCountry) {
+        tripCountries.add(tripCountry);
+        tripCountry.setTrip(this);
     }
 
     //==생성 메서드==//

--- a/src/main/java/zim/tave/memory/domain/TripCountry.java
+++ b/src/main/java/zim/tave/memory/domain/TripCountry.java
@@ -1,0 +1,63 @@
+package zim.tave.memory.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(
+        name = "TripCountry",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_trip_country_trip_country",
+                columnNames = {"tripId", "countryCode"}
+        )
+)
+public class TripCountry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tripCountryId")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tripId", nullable = false)
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "countryCode", nullable = false)
+    private Country country;
+
+    @Column(name = "createdAt", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+
+    public static TripCountry create(Trip trip, Country country) {
+        TripCountry tripCountry = new TripCountry();
+        tripCountry.setTrip(trip);
+        tripCountry.setCountry(country);
+        return tripCountry;
+    }
+}

--- a/src/main/java/zim/tave/memory/repository/DiaryRepository.java
+++ b/src/main/java/zim/tave/memory/repository/DiaryRepository.java
@@ -49,4 +49,18 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
           )
     """)
     boolean existsIncompleteDiaryByTripId(@Param("tripId") Long tripId);
+
+    @Query("""
+        SELECT CASE WHEN COUNT(d) > 0 THEN true ELSE false END
+        FROM Diary d
+        WHERE d.trip.id = :tripId
+          AND d.country.countryCode = :countryCode
+          AND d.id <> :excludedDiaryId
+          AND (d.isStored = false OR d.isStored IS NULL)
+    """)
+    boolean existsOtherActiveDiaryByTripIdAndCountryCode(
+            @Param("tripId") Long tripId,
+            @Param("countryCode") String countryCode,
+            @Param("excludedDiaryId") Long excludedDiaryId
+    );
 }

--- a/src/main/java/zim/tave/memory/repository/TripCountryRepository.java
+++ b/src/main/java/zim/tave/memory/repository/TripCountryRepository.java
@@ -1,0 +1,24 @@
+package zim.tave.memory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import zim.tave.memory.domain.TripCountry;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TripCountryRepository extends JpaRepository<TripCountry, Long> {
+
+    boolean existsByTrip_IdAndCountry_CountryCode(Long tripId, String countryCode);
+
+    Optional<TripCountry> findByTrip_IdAndCountry_CountryCode(Long tripId, String countryCode);
+
+    @Query("""
+            select tc from TripCountry tc
+            join fetch tc.trip t
+            join fetch tc.country
+            where t.id in :tripIds
+            """)
+    List<TripCountry> findByTripIdsWithCountry(@Param("tripIds") List<Long> tripIds);
+}

--- a/src/main/java/zim/tave/memory/service/DiaryService.java
+++ b/src/main/java/zim/tave/memory/service/DiaryService.java
@@ -34,6 +34,7 @@ public class DiaryService {
 	private final DiaryImageRepository diaryImageRepository;
     private final CountryService countryService;
     private final VisitedCountryService visitedCountryService;
+    private final TripCountryService tripCountryService;
 
     // 이미지 검증&저장
     private void validateAndAttachImages(Diary diary, List<CreateDiaryRequest.DiaryImageInfo> images) {
@@ -111,6 +112,8 @@ public class DiaryService {
 		Diary saved = diaryRepository.save(diary);
 
 		trip.updateEndDate(saved.getCreatedAt().toLocalDate());
+
+        tripCountryService.registerTripCountry(trip, country);
 
         // VisitedCountry 등록
         try {
@@ -214,7 +217,7 @@ public class DiaryService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional
+	@Transactional
     public void storeDiary(Long diaryId, Long userId, boolean isStored) {
         if (userId == null) {
             throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
@@ -227,6 +230,7 @@ public class DiaryService {
         }
 
         diary.setIsStored(isStored);
+        syncTripCountryForDiaryVisibility(diary, isStored);
     }
 
     @Transactional
@@ -237,6 +241,7 @@ public class DiaryService {
 		Diary diary = diaryRepository.findById(diaryId).orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
 		checkDiaryOwnership(userId, diary);
         Long tripId = diary.getTrip().getId();
+        removeTripCountryIfLastActiveDiary(diary);
 		diaryRepository.delete(diary);
 
         // 다이어리 삭제 후 Trip의 종료 날짜를 업데이트
@@ -259,6 +264,33 @@ public class DiaryService {
 		if (!diary.getUser().getId().equals(userId)) {
 			throw new CustomException(ErrorCode.ACCESS_DENIED);
 		}
+    }
+
+    private void syncTripCountryForDiaryVisibility(Diary diary, boolean isStored) {
+        if (isStored) {
+            removeTripCountryIfLastActiveDiary(diary);
+            return;
+        }
+        if (diary.getTrip() != null && diary.getCountry() != null) {
+            tripCountryService.registerTripCountry(diary.getTrip(), diary.getCountry());
+        }
+    }
+
+    private void removeTripCountryIfLastActiveDiary(Diary diary) {
+        if (diary.getTrip() == null || diary.getTrip().getId() == null
+                || diary.getCountry() == null || diary.getCountry().getCountryCode() == null
+                || diary.getId() == null) {
+            return;
+        }
+
+        boolean hasOtherActiveDiary = diaryRepository.existsOtherActiveDiaryByTripIdAndCountryCode(
+                diary.getTrip().getId(),
+                diary.getCountry().getCountryCode(),
+                diary.getId()
+        );
+        if (!hasOtherActiveDiary) {
+            tripCountryService.deleteTripCountry(diary.getTrip(), diary.getCountry());
+        }
     }
 
 	private DiaryResponseDto convertToDto(Diary diary) {

--- a/src/main/java/zim/tave/memory/service/TimelineService.java
+++ b/src/main/java/zim/tave/memory/service/TimelineService.java
@@ -8,12 +8,14 @@ import zim.tave.memory.domain.Diary;
 import zim.tave.memory.domain.DiaryImage;
 import zim.tave.memory.domain.Emotion;
 import zim.tave.memory.domain.Trip;
+import zim.tave.memory.domain.TripCountry;
 import zim.tave.memory.dto.TimelineTripDto;
 import zim.tave.memory.dto.VisitedCountryInfoDto;
 import zim.tave.memory.dto.response.TimelineResponseDto;
 import zim.tave.memory.global.common.exception.CustomException;
 import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.EmotionRepository;
+import zim.tave.memory.repository.TripCountryRepository;
 import zim.tave.memory.repository.TripRepository;
 
 import java.time.LocalDate;
@@ -32,6 +34,7 @@ public class TimelineService {
 
     private final TripRepository tripRepository;
     private final EmotionRepository emotionRepository;
+    private final TripCountryRepository tripCountryRepository;
 
     /**
      * 사용자의 타임라인 조회(보관함에 숨긴 여행 제외, 시작일 기준 내림차순 정렬 )
@@ -40,6 +43,7 @@ public class TimelineService {
         ensureAuthenticated(userId);
 
         List<Trip> trips = tripRepository.findActiveTripsWithDetails(userId);
+        Map<Long, List<TripCountry>> tripCountriesByTripId = loadTripCountriesByTripId(trips);
 
         // 활성 여행만 필터링하고 시작일 기준 내림차순 정렬
         List<TimelineTripDto> timelineTrips = trips.stream()
@@ -48,7 +52,10 @@ public class TimelineService {
                                 Trip::getStartDate,
                                 Comparator.nullsLast(LocalDate::compareTo))
                         .reversed())
-                .map(this::toTimelineTripDto)
+                .map(trip -> toTimelineTripDto(
+                        trip,
+                        tripCountriesByTripId.getOrDefault(trip.getId(), List.of())
+                ))
                 .toList();
 
         return TimelineResponseDto.builder()
@@ -59,7 +66,7 @@ public class TimelineService {
     /**
      * Trip 엔티티를 TimelineTripDto로 변환(가장 최근 일기에서 감정 정보 추출, 대표 이미지 URL 결정, 방문한 국가 목록 수집)
      */
-    private TimelineTripDto toTimelineTripDto(Trip trip) {
+    private TimelineTripDto toTimelineTripDto(Trip trip, List<TripCountry> tripCountries) {
         // 가장 최근 일기에서 감정 정보 추출
         TripEmotionInfo emotionInfo = resolveTripEmotion(trip);
         
@@ -73,14 +80,54 @@ public class TimelineService {
                 .representativeImageUrl(resolveRepresentativeImage(trip))
                 .emotionName(emotionInfo.emotionName())
                 .emotionColor(emotionInfo.emotionColor())
-                .visitedCountries(collectVisitedCountries(trip))
+                .visitedCountries(collectVisitedCountries(trip, tripCountries))
                 .build();
+    }
+
+    private Map<Long, List<TripCountry>> loadTripCountriesByTripId(List<Trip> trips) {
+        List<Long> tripIds = trips.stream()
+                .map(Trip::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (tripIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<TripCountry> tripCountries = tripCountryRepository.findByTripIdsWithCountry(tripIds);
+        if (tripCountries == null || tripCountries.isEmpty()) {
+            return Map.of();
+        }
+
+        return tripCountries.stream()
+                .filter(tripCountry -> tripCountry.getTrip() != null && tripCountry.getTrip().getId() != null)
+                .collect(Collectors.groupingBy(
+                        tripCountry -> tripCountry.getTrip().getId(),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
     }
 
     /**
      * 여행별 방문한 국가 목록을 수집(활성 일기에서 국가 정보 추출, 중복 제거, VisitedCountryInfoDto로 변환)
      */
-    private List<VisitedCountryInfoDto> collectVisitedCountries(Trip trip) {
+    private List<VisitedCountryInfoDto> collectVisitedCountries(Trip trip, List<TripCountry> tripCountries) {
+        if (tripCountries != null && !tripCountries.isEmpty()) {
+            return tripCountries.stream()
+                    .map(TripCountry::getCountry)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toMap(
+                            Country::getCountryCode,
+                            country -> country,
+                            (existing, duplicate) -> existing,
+                            LinkedHashMap::new
+                    ))
+                    .values()
+                    .stream()
+                    .map(this::buildVisitedCountryInfo)
+                    .toList();
+        }
+
         List<Diary> diaries = filterActiveDiaries(trip.getDiaries());
         if (diaries == null || diaries.isEmpty()) {
             return List.of();
@@ -220,4 +267,3 @@ public class TimelineService {
     private record TripEmotionInfo(String emotionName, String emotionColor) {
     }
 }
-

--- a/src/main/java/zim/tave/memory/service/TripCountryService.java
+++ b/src/main/java/zim/tave/memory/service/TripCountryService.java
@@ -1,0 +1,61 @@
+package zim.tave.memory.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import zim.tave.memory.domain.Country;
+import zim.tave.memory.domain.Trip;
+import zim.tave.memory.domain.TripCountry;
+import zim.tave.memory.repository.TripCountryRepository;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TripCountryService {
+
+    private final TripCountryRepository tripCountryRepository;
+    private final CountryService countryService;
+
+    public void registerTripCountries(Trip trip, List<String> countryCodes) {
+        if (countryCodes == null || countryCodes.isEmpty()) {
+            return;
+        }
+
+        Set<String> registeredCodes = new LinkedHashSet<>();
+        for (String countryCode : countryCodes) {
+            Country country = countryService.findByCode(countryCode);
+            if (registeredCodes.add(country.getCountryCode())) {
+                registerTripCountry(trip, country);
+            }
+        }
+    }
+
+    public void registerTripCountry(Trip trip, Country country) {
+        if (trip == null || trip.getId() == null || country == null || country.getCountryCode() == null) {
+            return;
+        }
+
+        boolean exists = tripCountryRepository.existsByTrip_IdAndCountry_CountryCode(
+                trip.getId(),
+                country.getCountryCode()
+        );
+        if (exists) {
+            return;
+        }
+
+        tripCountryRepository.save(TripCountry.create(trip, country));
+    }
+
+    public void deleteTripCountry(Trip trip, Country country) {
+        if (trip == null || trip.getId() == null || country == null || country.getCountryCode() == null) {
+            return;
+        }
+
+        tripCountryRepository.findByTrip_IdAndCountry_CountryCode(trip.getId(), country.getCountryCode())
+                .ifPresent(tripCountryRepository::delete);
+    }
+}

--- a/src/main/java/zim/tave/memory/service/TripService.java
+++ b/src/main/java/zim/tave/memory/service/TripService.java
@@ -28,6 +28,7 @@ public class TripService {
 	private final DiaryImageRepository diaryImageRepository;
     private final UserRepository userRepository;
     private final VisitedCountryService visitedCountryService;
+    private final TripCountryService tripCountryService;
     private final DiaryRepository diaryRepository;
 
     private TripService self; // self-injection 추가
@@ -99,6 +100,8 @@ public class TripService {
         trip.setIsStored(false);
 
         Trip saved = tripRepository.save(trip);
+
+        tripCountryService.registerTripCountries(saved, request.getCountryCodes());
 
         request.getCountryCodes().forEach(countryCode ->
                 visitedCountryService.registerVisitedCountry(userId, countryCode, request.getEmotionId()));

--- a/src/main/resources/db/migration/V6__create_trip_country.sql
+++ b/src/main/resources/db/migration/V6__create_trip_country.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `TripCountry` (
+    `tripCountryId` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `tripId` BIGINT NOT NULL,
+    `countryCode` VARCHAR(2) NOT NULL,
+    `createdAt` DATETIME(6) NOT NULL DEFAULT (UTC_TIMESTAMP()),
+    UNIQUE KEY `uk_trip_country_trip_country` (`tripId`, `countryCode`),
+    CONSTRAINT `fk_trip_country_trip` FOREIGN KEY (`tripId`) REFERENCES `Trip` (`tripId`) ON DELETE CASCADE,
+    CONSTRAINT `fk_trip_country_country` FOREIGN KEY (`countryCode`) REFERENCES `Country` (`countryCode`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/zim/tave/memory/integration/TimelineIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/TimelineIntegrationTest.java
@@ -111,7 +111,7 @@ public class TimelineIntegrationTest extends IntegrationTestBase {
         request.setDescription("2023년 유럽 배낭 여행");
         request.setStartDate(LocalDate.of(2023, 5, 1));
         request.setEndDate(LocalDate.of(2023, 5, 14));
-        request.setCountryCodes(Arrays.asList("FR", "IT"));
+        request.setCountryCodes(Arrays.asList("CN", "JP"));
         request.setEmotionId(defaultEmotion.getId());
 
         // when
@@ -128,6 +128,13 @@ public class TimelineIntegrationTest extends IntegrationTestBase {
         // 방문 국가가 등록되었는지 확인
         List<VisitedCountry> visitedCountries = visitedCountryRepository.findByUserIdWithDetails(testUser.getId());
         assertThat(visitedCountries).isNotEmpty();
+
+        TimelineResponseDto timeline = timelineService.getTimeline(testUser.getId());
+        assertThat(timeline.getTrips())
+                .filteredOn(trip -> trip.getTripId().equals(createdPastTrip.getId()))
+                .singleElement()
+                .satisfies(trip -> assertThat(trip.getVisitedCountries())
+                        .extracting("countryCode")
+                        .containsExactlyInAnyOrder("CN", "JP"));
     }
 }
-

--- a/src/test/java/zim/tave/memory/integration/TripDiaryIntegrationTest.java
+++ b/src/test/java/zim/tave/memory/integration/TripDiaryIntegrationTest.java
@@ -23,6 +23,7 @@ import zim.tave.memory.repository.EmotionRepository;
 import zim.tave.memory.repository.WeatherRepository;
 import zim.tave.memory.repository.DiaryImageRepository;
 import zim.tave.memory.service.CountryService;
+import zim.tave.memory.service.TripCountryService;
 import zim.tave.memory.service.VisitedCountryService;
 import zim.tave.memory.dto.response.TripResponseDto;
 
@@ -63,6 +64,9 @@ class TripDiaryIntegrationTest {
 
     @Mock
     private VisitedCountryService visitedCountryService;
+
+    @Mock
+    private TripCountryService tripCountryService;
 
     @InjectMocks
     private TripService tripService;

--- a/src/test/java/zim/tave/memory/service/DiaryServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/DiaryServiceTest.java
@@ -55,6 +55,9 @@ class DiaryServiceTest {
     @Mock
     private VisitedCountryService visitedCountryService;
 
+    @Mock
+    private TripCountryService tripCountryService;
+
     @InjectMocks
     private DiaryService diaryService;
 
@@ -134,6 +137,7 @@ class DiaryServiceTest {
         assertThat(result.getCity()).isEqualTo("서울");
         assertThat(result.getContent()).isEqualTo("테스트 내용");
         verify(diaryRepository).save(any(Diary.class));
+        verify(tripCountryService).registerTripCountry(trip, country);
     }
 
     @Test
@@ -225,6 +229,26 @@ class DiaryServiceTest {
     }
 
     @Test
+    void 다이어리_삭제_마지막_활성_국가면_TripCountry_삭제() {
+        // given
+        Country country = new Country("KR", "대한민국", "🇰🇷");
+        diary.setCountry(country);
+        trip.setStartDate(LocalDate.of(2024, 1, 1));
+
+        when(diaryRepository.findById(1L)).thenReturn(Optional.of(diary));
+        when(diaryRepository.existsOtherActiveDiaryByTripIdAndCountryCode(1L, "KR", 1L))
+                .thenReturn(false);
+        when(tripRepository.findById(1L)).thenReturn(Optional.of(trip));
+        when(diaryRepository.findByTrip_Id(1L)).thenReturn(List.of());
+
+        // when
+        diaryService.deleteDiary(1L, 1L);
+
+        // then
+        verify(tripCountryService).deleteTripCountry(trip, country);
+    }
+
+    @Test
     void 다이어리_삭제_후_남은_다이어리_있을_때_종료날짜_업데이트_테스트() {
         // given
         Diary remainingDiary = new Diary();
@@ -296,19 +320,26 @@ class DiaryServiceTest {
     @Test
     void 다이어리_보관_테스트() {
         // given
+        Country country = new Country("KR", "대한민국", "🇰🇷");
+        diary.setCountry(country);
         diary.setIsStored(false);
         when(diaryRepository.findById(1L)).thenReturn(Optional.of(diary));
+        when(diaryRepository.existsOtherActiveDiaryByTripIdAndCountryCode(1L, "KR", 1L))
+                .thenReturn(false);
 
         // when
         diaryService.storeDiary(1L, 1L, true);
 
         // then
         assertThat(diary.getIsStored()).isTrue();
+        verify(tripCountryService).deleteTripCountry(trip, country);
     }
 
     @Test
     void 다이어리_보관_해제_테스트() {
         // given
+        Country country = new Country("KR", "대한민국", "🇰🇷");
+        diary.setCountry(country);
         diary.setIsStored(true);
         when(diaryRepository.findById(1L)).thenReturn(Optional.of(diary));
 
@@ -317,6 +348,7 @@ class DiaryServiceTest {
 
         // then
         assertThat(diary.getIsStored()).isFalse();
+        verify(tripCountryService).registerTripCountry(trip, country);
     }
 
     @Test

--- a/src/test/java/zim/tave/memory/service/TimelineServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/TimelineServiceTest.java
@@ -11,12 +11,14 @@ import zim.tave.memory.domain.Diary;
 import zim.tave.memory.domain.DiaryImage;
 import zim.tave.memory.domain.Emotion;
 import zim.tave.memory.domain.Trip;
+import zim.tave.memory.domain.TripCountry;
 import zim.tave.memory.domain.User;
 import zim.tave.memory.dto.TimelineTripDto;
 import zim.tave.memory.dto.response.TimelineResponseDto;
 import zim.tave.memory.global.common.exception.CustomException;
 import zim.tave.memory.global.common.exception.ErrorCode;
 import zim.tave.memory.repository.EmotionRepository;
+import zim.tave.memory.repository.TripCountryRepository;
 import zim.tave.memory.repository.TripRepository;
 
 import java.time.LocalDate;
@@ -38,6 +40,9 @@ class TimelineServiceTest {
 
     @Mock
     private EmotionRepository emotionRepository;
+
+    @Mock
+    private TripCountryRepository tripCountryRepository;
 
     @InjectMocks
     private TimelineService timelineService;
@@ -254,6 +259,38 @@ class TimelineServiceTest {
     }
 
     @Test
+    void 타임라인_조회_과거여행_TripCountry_국가_수집() {
+        // given
+        Country china = new Country("CN", "중국", "🇨🇳");
+        Country japan = new Country("JP", "일본", "🇯🇵");
+
+        activeTrip.setIsPast(true);
+        activeTrip.setDiaries(new ArrayList<>());
+
+        Emotion defaultEmotion = new Emotion();
+        defaultEmotion.setId(1L);
+        defaultEmotion.setName("기본");
+        defaultEmotion.setColorCode("#EEEEEE");
+
+        when(tripRepository.findActiveTripsWithDetails(1L)).thenReturn(List.of(activeTrip));
+        when(tripCountryRepository.findByTripIdsWithCountry(List.of(activeTrip.getId())))
+                .thenReturn(List.of(
+                        TripCountry.create(activeTrip, china),
+                        TripCountry.create(activeTrip, japan)
+                ));
+        when(emotionRepository.findByName("기본")).thenReturn(defaultEmotion);
+
+        // when
+        TimelineResponseDto result = timelineService.getTimeline(1L);
+
+        // then
+        assertThat(result.getTrips()).hasSize(1);
+        assertThat(result.getTrips().get(0).getVisitedCountries())
+                .extracting("countryCode")
+                .containsExactlyInAnyOrder("CN", "JP");
+    }
+
+    @Test
     void 타임라인_조회_대표_이미지_해결() {
         // given
         String representativeImageUrl = "https://example.com/image.jpg";
@@ -428,4 +465,3 @@ class TimelineServiceTest {
         assertThat(result.getTrips().get(0).getEmotionColor()).isEqualTo("#EEEEEE");
     }
 }
-

--- a/src/test/java/zim/tave/memory/service/TripCountryServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/TripCountryServiceTest.java
@@ -1,0 +1,171 @@
+package zim.tave.memory.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import zim.tave.memory.domain.Country;
+import zim.tave.memory.domain.Trip;
+import zim.tave.memory.domain.TripCountry;
+import zim.tave.memory.repository.TripCountryRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TripCountryServiceTest {
+
+    @Mock
+    private TripCountryRepository tripCountryRepository;
+
+    @Mock
+    private CountryService countryService;
+
+    @InjectMocks
+    private TripCountryService tripCountryService;
+
+    private Trip trip;
+    private Country korea;
+
+    @BeforeEach
+    void setUp() {
+        trip = new Trip();
+        trip.setId(1L);
+
+        korea = new Country();
+        korea.setCountryCode("KR");
+        korea.setCountryName("대한민국");
+    }
+
+    @Test
+    void 여행_국가_목록이_null이면_등록하지_않음() {
+        // when
+        tripCountryService.registerTripCountries(trip, null);
+
+        // then
+        verifyNoInteractions(countryService, tripCountryRepository);
+    }
+
+    @Test
+    void 여행_국가_목록이_비어있으면_등록하지_않음() {
+        // when
+        tripCountryService.registerTripCountries(trip, List.of());
+
+        // then
+        verifyNoInteractions(countryService, tripCountryRepository);
+    }
+
+    @Test
+    void 여행_국가_목록_등록_시_해결된_국가코드가_중복이면_한번만_저장() {
+        // given
+        when(countryService.findByCode("KR")).thenReturn(korea);
+        when(tripCountryRepository.existsByTrip_IdAndCountry_CountryCode(1L, "KR"))
+                .thenReturn(false);
+
+        // when
+        tripCountryService.registerTripCountries(trip, List.of("KR", "KR"));
+
+        // then
+        verify(countryService, times(2)).findByCode("KR");
+        verify(tripCountryRepository, times(1))
+                .existsByTrip_IdAndCountry_CountryCode(1L, "KR");
+        verify(tripCountryRepository, times(1)).save(any(TripCountry.class));
+    }
+
+    @Test
+    void 여행_국가가_이미_등록되어_있으면_저장하지_않음() {
+        // given
+        when(tripCountryRepository.existsByTrip_IdAndCountry_CountryCode(1L, "KR"))
+                .thenReturn(true);
+
+        // when
+        tripCountryService.registerTripCountry(trip, korea);
+
+        // then
+        verify(tripCountryRepository).existsByTrip_IdAndCountry_CountryCode(1L, "KR");
+        verify(tripCountryRepository, never()).save(any(TripCountry.class));
+    }
+
+    @Test
+    void 여행_국가가_없으면_새로_저장() {
+        // given
+        when(tripCountryRepository.existsByTrip_IdAndCountry_CountryCode(1L, "KR"))
+                .thenReturn(false);
+
+        // when
+        tripCountryService.registerTripCountry(trip, korea);
+
+        // then
+        ArgumentCaptor<TripCountry> captor = ArgumentCaptor.forClass(TripCountry.class);
+        verify(tripCountryRepository).save(captor.capture());
+
+        TripCountry saved = captor.getValue();
+        assertThat(saved.getTrip()).isSameAs(trip);
+        assertThat(saved.getCountry()).isSameAs(korea);
+    }
+
+    @Test
+    void 여행_국가_등록_방어로직은_저장소를_호출하지_않음() {
+        // given
+        Trip tripWithoutId = new Trip();
+        Country countryWithoutCode = new Country();
+
+        // when
+        tripCountryService.registerTripCountry(null, korea);
+        tripCountryService.registerTripCountry(tripWithoutId, korea);
+        tripCountryService.registerTripCountry(trip, null);
+        tripCountryService.registerTripCountry(trip, countryWithoutCode);
+
+        // then
+        verifyNoInteractions(tripCountryRepository);
+    }
+
+    @Test
+    void 여행_국가_삭제_대상이_있으면_삭제() {
+        // given
+        TripCountry tripCountry = TripCountry.create(trip, korea);
+        when(tripCountryRepository.findByTrip_IdAndCountry_CountryCode(1L, "KR"))
+                .thenReturn(Optional.of(tripCountry));
+
+        // when
+        tripCountryService.deleteTripCountry(trip, korea);
+
+        // then
+        verify(tripCountryRepository).delete(tripCountry);
+    }
+
+    @Test
+    void 여행_국가_삭제_대상이_없으면_삭제하지_않음() {
+        // given
+        when(tripCountryRepository.findByTrip_IdAndCountry_CountryCode(1L, "KR"))
+                .thenReturn(Optional.empty());
+
+        // when
+        tripCountryService.deleteTripCountry(trip, korea);
+
+        // then
+        verify(tripCountryRepository, never()).delete(any(TripCountry.class));
+    }
+
+    @Test
+    void 여행_국가_삭제_방어로직은_저장소를_호출하지_않음() {
+        // given
+        Trip tripWithoutId = new Trip();
+        Country countryWithoutCode = new Country();
+
+        // when
+        tripCountryService.deleteTripCountry(null, korea);
+        tripCountryService.deleteTripCountry(tripWithoutId, korea);
+        tripCountryService.deleteTripCountry(trip, null);
+        tripCountryService.deleteTripCountry(trip, countryWithoutCode);
+
+        // then
+        verifyNoInteractions(tripCountryRepository);
+    }
+}

--- a/src/test/java/zim/tave/memory/service/TripServiceTest.java
+++ b/src/test/java/zim/tave/memory/service/TripServiceTest.java
@@ -45,6 +45,9 @@ class TripServiceTest {
     private VisitedCountryService visitedCountryService;
 
     @Mock
+    private TripCountryService tripCountryService;
+
+    @Mock
     private DiaryRepository diaryRepository;
 
     @InjectMocks
@@ -282,6 +285,7 @@ class TripServiceTest {
         assertThat(result.getEndDate()).isEqualTo(request.getEndDate());
         verify(visitedCountryService).registerVisitedCountry(1L, "FR", 2L);
         verify(visitedCountryService).registerVisitedCountry(1L, "IT", 2L);
+        verify(tripCountryService).registerTripCountries(any(Trip.class), eq(request.getCountryCodes()));
     }
 
     @Test


### PR DESCRIPTION
## 🔗 Related Issue
- #94

## 📝 Description
> 무엇을(What), 왜(Why) 변경했는지 설명합니다.

### 기획 배경 및 비즈니스 문제
- `POST /api/users/me/timeline/past` 요청으로 과거 여행 생성 시 `countryCodes`는 저장되지만, 생성 직후 `GET /api/users/me/timeline` 응답의 `visitedCountries`가 빈 배열로 내려오는 문제를 해결했습니다.
- 사용자 전체 방문 국가 기록인 `VisitedCountry`와 여행 단위 국가 정보가 분리되어 있지 않아, 일기가 없는 과거 여행의 국가 정보를 타임라인에서 수집할 수 없었습니다.
- 여행별 국가 정보를 저장하는 `TripCountry`를 추가하여 과거 여행과 현재 여행 모두 타임라인에서 국가 정보를 안정적으로 응답하도록 개선했습니다.

## 🛠 Changes
> 핵심 변경 사항을 요약합니다.

- **DB 스키마**: `TripCountry` 테이블 생성 마이그레이션 추가
- **도메인**: `TripCountry` 엔티티 추가 및 `Trip`과 여행-국가 연관관계 설정
- **Repository**: 여행별 국가 조회/중복 확인/삭제를 위한 `TripCountryRepository` 추가
- **Service**:
  - 과거 여행 생성 시 `countryCodes`를 `TripCountry`에 저장
  - 일기 생성 시 선택 국가를 해당 여행의 `TripCountry`에 등록
  - 일기 보관/삭제 시 활성 일기 여부에 따라 `TripCountry` 동기화
  - 타임라인 조회 시 `TripCountry` 기반으로 `visitedCountries` 매핑
- **Test**:
  - `TripService`, `DiaryService`, `TimelineService` 단위 테스트에 `TripCountry` 연동 검증 추가
  - 과거 여행의 `TripCountry` 국가 정보가 타임라인 응답에 포함되는 케이스 검증

## ✅ Test Checklist
> 변경 사항이 정상적으로 동작하는지 확인하기 위해 수행한 테스트 목록입니다.

- [x] 단위 테스트(Unit Test)를 작성하고 통과했나요?
- [x] 관련 API 응답 결과가 기획서와 일치하는지 확인했나요?
